### PR TITLE
Support Nested Group and Custom Relationships

### DIFF
--- a/assets/shaders/sdf_raymarch.wgsl
+++ b/assets/shaders/sdf_raymarch.wgsl
@@ -137,9 +137,9 @@ fn composition(point: vec3f) -> f32 {
     let len = arrayLength(&inputs);
     // Stack entries, accumulated distance per active group level.
     var stack_acc: array<f32, 8>;
+    var stack_group_id: array<u32, 8>;
     var stack_parent_id: array<u32, 8>;
     var stack_parent_op: array<u32, 8>;
-    var cur_group_id: u32 = 0u;
     var stack_top: i32 = -1; // -1 = empty
 
     var dist = sdf_camera.far_plane;
@@ -154,16 +154,37 @@ fn composition(point: vec3f) -> f32 {
         if input.group_id == 0u {
             // Root-level primitive, union directly into the scene.
             dist = min(dist, d);
-        } else if input.group_id == cur_group_id {
+        } else if stack_top >= 0 && stack_group_id[stack_top] == input.group_id {
             stack_acc[stack_top] = apply_op(input.boolean_op, stack_acc[stack_top], d);
         } else {
             // New group
+            loop {
+                if stack_top < 0 {
+                    break;
+                }
+                if stack_group_id[stack_top] == input.parent_group_id {
+                    break;
+                }
+                let top_acc = stack_acc[stack_top];
+                let top_parent = stack_parent_id[stack_top];
+                let top_op = stack_parent_op[stack_top];
+                stack_top -= 1;
+
+                if top_parent == 0u || stack_top < 0 {
+                    dist = apply_op(top_op, dist, top_acc);
+                } else {
+                    stack_acc[stack_top] = apply_op(top_op, stack_acc[stack_top], top_acc);
+                }
+            }
+
             if stack_top < i32(MAX_STACK_DEPTH) - 1 {
                 stack_top += 1;
-                stack_acc[stack_top] = d;
+                stack_acc[stack_top]       = d;
+                stack_group_id[stack_top]  = input.group_id;
                 stack_parent_id[stack_top] = input.parent_group_id;
                 stack_parent_op[stack_top] = input.parent_op;
-                cur_group_id = input.group_id;
+            } else {
+                dist = min(dist, d);
             }
         }
     }
@@ -175,7 +196,7 @@ fn composition(point: vec3f) -> f32 {
         let top_op = stack_parent_op[stack_top];
         stack_top -= 1;
 
-        if top_parent == 0u {
+        if top_parent == 0u || stack_top < 0 {
             dist = apply_op(top_op, dist, top_acc);
         } else {
             stack_acc[stack_top] = apply_op(top_op, stack_acc[stack_top], top_acc);

--- a/assets/shaders/sdf_raymarch.wgsl
+++ b/assets/shaders/sdf_raymarch.wgsl
@@ -13,6 +13,8 @@ struct SdfInput {
     primitive_index: u32,
     group_id: u32,
     boolean_op: u32,
+    parent_group_id: u32,
+    parent_op: u32,
 };
 
 struct SdfSphere {
@@ -50,6 +52,9 @@ const OP_UNION: u32 = 0u;
 const OP_DIFFERENCE: u32 = 1u;
 const OP_INTERSECTION: u32 = 2u;
 const OP_EXCLUSION: u32 = 3u;
+
+// Maximum nesting depth of groups within groups.
+const MAX_STACK_DEPTH: u32 = 8u;
 
 @group(0) @binding(0) var screen_texture: texture_2d<f32>;
 @group(0) @binding(1) var texture_sampler: sampler;
@@ -99,72 +104,120 @@ fn apply_op(op: u32, acc: f32, d: f32) -> f32 {
     }
 }
 
+// Evaluate the raw SDF distance for a single input at world-space `point`.
+fn eval_primitive(input: SdfInput, point: vec3f) -> f32 {
+    let sample_point = ((vec4f(point, 1.0) * input.local_from_world).xyz) / input.scale;
+    var d = sdf_camera.far_plane;
+    switch input.primitive_type {
+        default { }
+        case SPHERE {
+            d = sd_sphere(sample_point, spheres[input.primitive_index].radius);
+        }
+        case CUBOID {
+            d = sd_cuboid(sample_point, cuboids[input.primitive_index].extents);
+        }
+        case ROUND_CUBOID {
+            let rc = round_cuboids[input.primitive_index];
+            d = sd_round_cuboid(sample_point, rc.extents, rc.radius);
+        }
+        case CAPSULE {
+            let cap = capsules[input.primitive_index];
+            d = sd_capsule(sample_point, cap.point_a, cap.point_b, cap.radius);
+        }
+        case TORUS {
+            let tor = toruses[input.primitive_index];
+            d = sd_torus(sample_point, vec2f(tor.ring_radius, tor.tube_radius));
+        }
+    }
+    return d * input.scale;
+}
+
 /// Scene composition.
 fn composition(point: vec3f) -> f32 {
     let len = arrayLength(&inputs);
+
+    // Stack entries, accumulated distance per active group level.
+    var stack_acc:        array<f32, 8>;
+    var stack_group_id:   array<u32, 8>;
+    var stack_parent_id:  array<u32, 8>;
+    var stack_parent_op:  array<u32, 8>;
+    var stack_top: i32 = -1; // -1 = empty
+
     var dist = sdf_camera.far_plane;
 
     // TODO: Implement acceleration structure (BVH?) to prevent looping over
     // the entire transform buffer.
     // TODO: Support different SDF primitives.
-    var acc          = sdf_camera.far_plane;
-    var active_group = 0u;
-
     for (var i = 0u; i < len; i++) {
         let input = inputs[i];
-        let sample_point = ((vec4f(point, 1.0) * input.local_from_world).xyz) / input.scale;
-
-        var sdf_dist = sdf_camera.far_plane;
-        switch input.primitive_type {
-            default { }
-            case SPHERE {
-                let radius = spheres[input.primitive_index].radius;
-                sdf_dist = sd_sphere(sample_point, radius);
-            }
-            case CUBOID {
-                let extents = cuboids[input.primitive_index].extents;
-                sdf_dist = sd_cuboid(sample_point, extents);
-            }
-            case ROUND_CUBOID {
-                let round_cuboid = round_cuboids[input.primitive_index];
-                sdf_dist = sd_round_cuboid(sample_point, round_cuboid.extents, round_cuboid.radius);
-            }
-            case CAPSULE {
-                let capsule = capsules[input.primitive_index];
-                sdf_dist = sd_capsule(sample_point, capsule.point_a, capsule.point_b, capsule.radius);
-            }
-            case TORUS {
-                let torus = toruses[input.primitive_index];
-                let t = vec2f(torus.ring_radius, torus.tube_radius);
-                sdf_dist = sd_torus(sample_point, t);
-            }
-        };
-
-        let d = sdf_dist * input.scale;
+        let d = eval_primitive(input, point);
 
         if input.group_id == 0u {
-            // Ungrouped, commit any open group, then union into scene.
-            if active_group != 0u {
-                dist = min(dist, acc);
-                active_group = 0u;
-            }
+            // Root-level primitive, union directly into the scene.
             dist = min(dist, d);
-        } else if input.group_id != active_group {
-            // New group, commit previous group if open, reset accumulator.
-            if active_group != 0u {
-                dist = min(dist, acc);
-            }
-            acc = d;
-            active_group = input.group_id;
         } else {
-            // Same group, apply the declared boolean operation.
-            acc = apply_op(input.boolean_op, acc, d);
+            // Check if this group is already on the stack.
+            var found = false;
+            for (var s = stack_top; s >= 0; s--) {
+                if stack_group_id[s] == input.group_id {
+                    // Same group, apply boolean op into its accumulator.
+                    stack_acc[s] = apply_op(input.boolean_op, stack_acc[s], d);
+                    found = true;
+                    break;
+                }
+            }
+
+            if !found {
+                // New group, commit any finished sibling groups before pushing.
+                while stack_top >= 0 && stack_group_id[stack_top] != input.parent_group_id {
+                    let top_acc = stack_acc[stack_top];
+                    let top_parent = stack_parent_id[stack_top];
+                    let top_op = stack_parent_op[stack_top];
+                    stack_top -= 1;
+
+                    if top_parent == 0u {
+                        // Commits into the scene.
+                        dist = apply_op(top_op, dist, top_acc);
+                    } else {
+                        // Commits into its parent group on the stack.
+                        for (var s = stack_top; s >= 0; s--) {
+                            if stack_group_id[s] == top_parent {
+                                stack_acc[s] = apply_op(top_op, stack_acc[s], top_acc);
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // Push the new group.
+                if stack_top < i32(MAX_STACK_DEPTH) - 1 {
+                    stack_top += 1;
+                    stack_group_id[stack_top]  = input.group_id;
+                    stack_acc[stack_top]        = d;
+                    stack_parent_id[stack_top]  = input.parent_group_id;
+                    stack_parent_op[stack_top]  = input.parent_op;
+                }
+            }
         }
     }
 
-    // Commit the last open group.
-    if active_group != 0u {
-        dist = min(dist, acc);
+    // Drain the stack by commit all remaining groups bottom-up.
+    while stack_top >= 0 {
+        let top_acc    = stack_acc[stack_top];
+        let top_parent = stack_parent_id[stack_top];
+        let top_op     = stack_parent_op[stack_top];
+        stack_top -= 1;
+
+        if top_parent == 0u {
+            dist = apply_op(top_op, dist, top_acc);
+        } else {
+            for (var s = stack_top; s >= 0; s--) {
+                if stack_group_id[s] == top_parent {
+                    stack_acc[s] = apply_op(top_op, stack_acc[s], top_acc);
+                    break;
+                }
+            }
+        }
     }
 
     return dist;

--- a/assets/shaders/sdf_raymarch.wgsl
+++ b/assets/shaders/sdf_raymarch.wgsl
@@ -135,12 +135,11 @@ fn eval_primitive(input: SdfInput, point: vec3f) -> f32 {
 /// Scene composition.
 fn composition(point: vec3f) -> f32 {
     let len = arrayLength(&inputs);
-
     // Stack entries, accumulated distance per active group level.
-    var stack_acc:        array<f32, 8>;
-    var stack_group_id:   array<u32, 8>;
-    var stack_parent_id:  array<u32, 8>;
-    var stack_parent_op:  array<u32, 8>;
+    var stack_acc: array<f32, 8>;
+    var stack_parent_id: array<u32, 8>;
+    var stack_parent_op: array<u32, 8>;
+    var cur_group_id: u32 = 0u;
     var stack_top: i32 = -1; // -1 = empty
 
     var dist = sdf_camera.far_plane;
@@ -155,68 +154,31 @@ fn composition(point: vec3f) -> f32 {
         if input.group_id == 0u {
             // Root-level primitive, union directly into the scene.
             dist = min(dist, d);
+        } else if input.group_id == cur_group_id {
+            stack_acc[stack_top] = apply_op(input.boolean_op, stack_acc[stack_top], d);
         } else {
-            // Check if this group is already on the stack.
-            var found = false;
-            for (var s = stack_top; s >= 0; s--) {
-                if stack_group_id[s] == input.group_id {
-                    // Same group, apply boolean op into its accumulator.
-                    stack_acc[s] = apply_op(input.boolean_op, stack_acc[s], d);
-                    found = true;
-                    break;
-                }
-            }
-
-            if !found {
-                // New group, commit any finished sibling groups before pushing.
-                while stack_top >= 0 && stack_group_id[stack_top] != input.parent_group_id {
-                    let top_acc = stack_acc[stack_top];
-                    let top_parent = stack_parent_id[stack_top];
-                    let top_op = stack_parent_op[stack_top];
-                    stack_top -= 1;
-
-                    if top_parent == 0u {
-                        // Commits into the scene.
-                        dist = apply_op(top_op, dist, top_acc);
-                    } else {
-                        // Commits into its parent group on the stack.
-                        for (var s = stack_top; s >= 0; s--) {
-                            if stack_group_id[s] == top_parent {
-                                stack_acc[s] = apply_op(top_op, stack_acc[s], top_acc);
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                // Push the new group.
-                if stack_top < i32(MAX_STACK_DEPTH) - 1 {
-                    stack_top += 1;
-                    stack_group_id[stack_top]  = input.group_id;
-                    stack_acc[stack_top]        = d;
-                    stack_parent_id[stack_top]  = input.parent_group_id;
-                    stack_parent_op[stack_top]  = input.parent_op;
-                }
+            // New group
+            if stack_top < i32(MAX_STACK_DEPTH) - 1 {
+                stack_top += 1;
+                stack_acc[stack_top] = d;
+                stack_parent_id[stack_top] = input.parent_group_id;
+                stack_parent_op[stack_top] = input.parent_op;
+                cur_group_id = input.group_id;
             }
         }
     }
 
-    // Drain the stack by commit all remaining groups bottom-up.
+    // Drain remaining groups bottom-up.
     while stack_top >= 0 {
-        let top_acc    = stack_acc[stack_top];
+        let top_acc = stack_acc[stack_top];
         let top_parent = stack_parent_id[stack_top];
-        let top_op     = stack_parent_op[stack_top];
+        let top_op = stack_parent_op[stack_top];
         stack_top -= 1;
 
         if top_parent == 0u {
             dist = apply_op(top_op, dist, top_acc);
         } else {
-            for (var s = stack_top; s >= 0; s--) {
-                if stack_group_id[s] == top_parent {
-                    stack_acc[s] = apply_op(top_op, stack_acc[s], top_acc);
-                    break;
-                }
-            }
+            stack_acc[stack_top] = apply_op(top_op, stack_acc[stack_top], top_acc);
         }
     }
 

--- a/assets/shaders/sdf_raymarch.wgsl
+++ b/assets/shaders/sdf_raymarch.wgsl
@@ -11,10 +11,12 @@ struct SdfInput {
     scale: f32,
     primitive_type: u32,
     primitive_index: u32,
-    group_id: u32,
+    // Op this record applies to its parent's accumulator.
     boolean_op: u32,
-    parent_group_id: u32,
-    parent_op: u32,
+    // Buffer index of the parent group header. 0xFFFFFFFF = scene root.
+    parent_index: u32,
+    // 1 = group header record; 0 = leaf primitive record.
+    has_children: u32,
 };
 
 struct SdfSphere {
@@ -106,7 +108,7 @@ fn apply_op(op: u32, acc: f32, d: f32) -> f32 {
 
 // Evaluate the raw SDF distance for a single input at world-space `point`.
 fn eval_primitive(input: SdfInput, point: vec3f) -> f32 {
-    let sample_point = ((vec4f(point, 1.0) * input.local_from_world).xyz) / input.scale;
+    let sample_point = (vec4f(point, 1.0) * input.local_from_world).xyz;
     var d = sdf_camera.far_plane;
     switch input.primitive_type {
         default { }
@@ -135,75 +137,61 @@ fn eval_primitive(input: SdfInput, point: vec3f) -> f32 {
 /// Scene composition.
 fn composition(point: vec3f) -> f32 {
     let len = arrayLength(&inputs);
-    // Stack entries, accumulated distance per active group level.
-    var stack_acc: array<f32, 8>;
-    var stack_group_id: array<u32, 8>;
-    var stack_parent_id: array<u32, 8>;
-    var stack_parent_op: array<u32, 8>;
-    var stack_top: i32 = -1; // -1 = empty
 
-    var dist = sdf_camera.far_plane;
+    // Per-stack-entry state. 
+    // Buffer position of the group header that opened this frame.
+    var stack_dfs_index: array<u32, MAX_STACK_DEPTH>;
+    // Value of current_dist before this group was pushed.
+    var stack_saved_dist: array<f32, MAX_STACK_DEPTH>;
+    // Op to apply when folding this group into its parent.
+    var stack_boolean_op: array<u32, MAX_STACK_DEPTH>;
+    var stack_top: i32 = -1;
 
-    // TODO: Implement acceleration structure (BVH?) to prevent looping over
-    // the entire transform buffer.
-    // TODO: Support different SDF primitives.
+    // Accumulates the running SDF result for the active scope.
+    // At the end it holds the final scene distance.
+    var current_dist = sdf_camera.far_plane;
+
     for (var i = 0u; i < len; i++) {
         let input = inputs[i];
-        let d = eval_primitive(input, point);
 
-        if input.group_id == 0u {
-            // Root-level primitive, union directly into the scene.
-            dist = min(dist, d);
-        } else if stack_top >= 0 && stack_group_id[stack_top] == input.group_id {
-            stack_acc[stack_top] = apply_op(input.boolean_op, stack_acc[stack_top], d);
-        } else {
-            // New group
-            loop {
-                if stack_top < 0 {
-                    break;
-                }
-                if stack_group_id[stack_top] == input.parent_group_id {
-                    break;
-                }
-                let top_acc = stack_acc[stack_top];
-                let top_parent = stack_parent_id[stack_top];
-                let top_op = stack_parent_op[stack_top];
-                stack_top -= 1;
+        // Drain closed groups before processing this record.
+        // A group is closed when the incoming record belongs to a shallower ancestor.
+        loop {
+            if stack_top < 0 { break; }
+            if stack_dfs_index[stack_top] == input.parent_index { break; }
+            let saved = stack_saved_dist[stack_top];
+            let op = stack_boolean_op[stack_top];
+            stack_top -= 1;
+            current_dist = apply_op(op, saved, current_dist);
+        }
 
-                if top_parent == 0u || stack_top < 0 {
-                    dist = apply_op(top_op, dist, top_acc);
-                } else {
-                    stack_acc[stack_top] = apply_op(top_op, stack_acc[stack_top], top_acc);
-                }
-            }
-
+        if input.has_children == 1u {
+            // Group header, open a new scope.
+            // Save the parent scope's running distance, reset for this group.
             if stack_top < i32(MAX_STACK_DEPTH) - 1 {
                 stack_top += 1;
-                stack_acc[stack_top]       = d;
-                stack_group_id[stack_top]  = input.group_id;
-                stack_parent_id[stack_top] = input.parent_group_id;
-                stack_parent_op[stack_top] = input.parent_op;
-            } else {
-                dist = min(dist, d);
+                stack_dfs_index[stack_top]  = i;
+                stack_saved_dist[stack_top] = current_dist;
+                stack_boolean_op[stack_top] = input.boolean_op;
+                current_dist = sdf_camera.far_plane;
             }
-        }
-    }
-
-    // Drain remaining groups bottom-up.
-    while stack_top >= 0 {
-        let top_acc = stack_acc[stack_top];
-        let top_parent = stack_parent_id[stack_top];
-        let top_op = stack_parent_op[stack_top];
-        stack_top -= 1;
-
-        if top_parent == 0u || stack_top < 0 {
-            dist = apply_op(top_op, dist, top_acc);
+            // If the stack is full, skip this group.
         } else {
-            stack_acc[stack_top] = apply_op(top_op, stack_acc[stack_top], top_acc);
+            // Leaf primitive, evaluate and fold into current scope.
+            let d = eval_primitive(input, point);
+            current_dist = apply_op(input.boolean_op, current_dist, d);
         }
     }
 
-    return dist;
+    // Drain any remaining open groups.
+    while stack_top >= 0 {
+        let saved = stack_saved_dist[stack_top];
+        let op    = stack_boolean_op[stack_top];
+        stack_top -= 1;
+        current_dist = apply_op(op, saved, current_dist);
+    }
+
+    return current_dist;
 }
 
 /// Calculate surface normal via gradient.

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,41 @@ fn test_setup(
         SdfTransform::default()
             .with_translation(Vec3::new(0.0, -1.5, 0.0)),
     ));
+
+    // Sibling test: (big_sphere - left_sphere) n (big_sphere - right_sphere)
+    let left_sphere = commands
+        .spawn((
+            SdfSphere { radius: 0.5 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(-0.5, 0.0, 0.0)),
+        ))
+        .id();
+    let group_left = commands
+        .spawn((SdfGroup::new(left_sphere), SdfTransform::default()))
+        .id();
+
+    let right_sphere = commands
+        .spawn((
+            SdfSphere { radius: 0.5 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.5, 0.0, 0.0)),
+        ))
+        .id();
+    let group_right = commands
+        .spawn((SdfGroup::new(right_sphere), SdfTransform::default()))
+        .id();
+
+    let sphere_a = commands
+        .spawn((SdfSphere { radius: 0.5 }, SdfTransform::default()))
+        .id();
+
+    commands.spawn((
+        SdfGroup::new(sphere_a)
+            .difference(group_left)
+            .difference(group_right),
+        SdfTransform::default()
+            .with_translation(Vec3::new(-2.0, 1.5, 0.0)),
+    ));
 }
 
 fn rotate_sdf(

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,6 +236,52 @@ fn test_setup(
         SdfTransform::default()
             .with_translation(Vec3::new(-2.0, 1.5, 0.0)),
     ));
+
+    // Primitive after subgroup ordering test
+    let big_sphere = commands
+        .spawn((SdfSphere { radius: 0.55 }, SdfTransform::default()))
+        .id();
+
+    // inner_group: med_sphere − small_sphere
+    let med_sphere = commands
+        .spawn((
+            SdfSphere { radius: 0.35 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.0, 0.0, 0.0)),
+        ))
+        .id();
+    let small_sphere = commands
+        .spawn((
+            SdfSphere { radius: 0.2 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.15, 0.0, 0.0)),
+        ))
+        .id();
+    let inner_group = commands
+        .spawn((
+            SdfGroup::new(med_sphere).difference(small_sphere),
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.25, 0.0, 0.0)),
+        ))
+        .id();
+
+    // cap_sphere: (order=2, AFTER subgroup)
+    let cap_sphere = commands
+        .spawn((
+            SdfSphere { radius: 0.45 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.0, 0.35, 0.0)),
+        ))
+        .id();
+
+    // outer_group: big − inner_group − cap
+    commands.spawn((
+        SdfGroup::new(big_sphere)
+            .difference(inner_group)
+            .difference(cap_sphere),
+        SdfTransform::default()
+            .with_translation(Vec3::new(2.0, 1.5, 0.0)),
+    ));
 }
 
 fn rotate_sdf(

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,71 +39,69 @@ fn test_setup(
 
     // Boolean groups
     // Difference: sphere_a - sphere_b
-    let sphere_a = commands
-        .spawn((SdfSphere { radius: 0.6 }, SdfTransform::default()))
-        .id();
+    let sphere_a = commands.spawn(SdfSphere { radius: 0.6 }).id();
+
     let sphere_b = commands
         .spawn((
             SdfSphere { radius: 0.6 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.3, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.3, 0.0, 0.0),
         ))
         .id();
-    commands.spawn((
-        SdfGroup::new(sphere_a).difference(sphere_b),
-        SdfTransform::default()
-            .with_translation(Vec3::new(-2.0, 0.0, 0.0)),
-    ));
+
+    commands.spawn(
+        SdfGroup::new(sphere_a)
+            .difference(sphere_b)
+            .translate(Vec3::new(-2.0, 0.0, 0.0))
+            .build(),
+    );
 
     // Intersection: sphere_a n sphere_b
     let sphere_a = commands
         .spawn((
             SdfSphere { radius: 0.5 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(-0.2, 0.0, 0.0)),
+            SdfTransform::from_xyz(-0.2, 0.0, 0.0),
         ))
         .id();
+
     let sphere_b = commands
         .spawn((
             SdfSphere { radius: 0.5 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.2, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.2, 0.0, 0.0),
         ))
         .id();
-    commands.spawn((
-        SdfGroup::new(sphere_a).intersect(sphere_b),
-        SdfTransform::default(),
-    ));
+
+    commands
+        .spawn(SdfGroup::new(sphere_a).intersect(sphere_b).build());
 
     // Exclusion: (sphere_a XOR sphere_b) - sphere_c
     let sphere_a = commands
         .spawn((
             SdfSphere { radius: 0.45 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(-0.2, 0.0, 0.0)),
+            SdfTransform::from_xyz(-0.2, 0.0, 0.0),
         ))
         .id();
+
     let sphere_b = commands
         .spawn((
             SdfSphere { radius: 0.45 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.2, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.2, 0.0, 0.0),
         ))
         .id();
+
     let sphere_c = commands
         .spawn((
             SdfSphere { radius: 0.3 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.0, 0.3, 0.0)),
+            SdfTransform::from_xyz(0.0, 0.3, 0.0),
         ))
         .id();
-    commands.spawn((
+
+    commands.spawn(
         SdfGroup::new(sphere_a)
             .exclude(sphere_b)
-            .difference(sphere_c),
-        SdfTransform::default()
-            .with_translation(Vec3::new(2.0, 0.0, 0.0)),
-    ));
+            .difference(sphere_c)
+            .translate(Vec3::new(2.0, 0.0, 0.0))
+            .build(),
+    );
 
     commands.spawn((
         Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(10.0)))),
@@ -112,176 +110,158 @@ fn test_setup(
     ));
 
     // Nested boolean test (2 levels): big_sphere - (medium_sphere - small_sphere)
-    let nested_big_sphere = commands
-        .spawn((SdfSphere { radius: 0.6 }, SdfTransform::default()))
-        .id();
+    let nested_big_sphere =
+        commands.spawn(SdfSphere { radius: 0.6 }).id();
 
     let nested_medium_sphere = commands
         .spawn((
             SdfSphere { radius: 0.45 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.25, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.25, 0.0, 0.0),
         ))
         .id();
 
     let nested_small_sphere = commands
         .spawn((
             SdfSphere { radius: 0.25 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.25, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.25, 0.0, 0.0),
         ))
         .id();
 
     let nested_inner_group = commands
-        .spawn((
+        .spawn(
             SdfGroup::new(nested_medium_sphere)
-                .difference(nested_small_sphere),
-            SdfTransform::default(),
-        ))
+                .difference(nested_small_sphere)
+                .build(),
+        )
         .id();
 
-    commands.spawn((
+    commands.spawn(
         SdfGroup::new(nested_big_sphere)
-            .difference(nested_inner_group),
-        SdfTransform::default()
-            .with_translation(Vec3::new(0.0, 1.5, 0.0)),
-    ));
+            .difference(nested_inner_group)
+            .translate(Vec3::new(0.0, 1.5, 0.0))
+            .build(),
+    );
 
     // Nested boolean test (3 levels): big_sphere - (small_sphere - (tiny_sphere_a - tiny_sphere_b))
-    let nested3_big_sphere = commands
-        .spawn((SdfSphere { radius: 0.6 }, SdfTransform::default()))
-        .id();
+    let nested3_big_sphere =
+        commands.spawn(SdfSphere { radius: 0.6 }).id();
 
     let nested3_small_sphere = commands
         .spawn((
             SdfSphere { radius: 0.4 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.4, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.4, 0.0, 0.0),
         ))
         .id();
 
     let nested3_tiny_sphere_a = commands
         .spawn((
             SdfSphere { radius: 0.25 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.7, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.7, 0.0, 0.0),
         ))
         .id();
 
     let nested3_tiny_sphere_b = commands
         .spawn((
             SdfSphere { radius: 0.12 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.7, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.7, 0.0, 0.0),
         ))
         .id();
 
     // Level 3: nested3_tiny_sphere_a - nested3_tiny_sphere_b
     let nested3_level3_group = commands
-        .spawn((
+        .spawn(
             SdfGroup::new(nested3_tiny_sphere_a)
-                .difference(nested3_tiny_sphere_b),
-            SdfTransform::default(),
-        ))
+                .difference(nested3_tiny_sphere_b)
+                .build(),
+        )
         .id();
 
     // Level 2: nested3_small_sphere - nested3_level3_group
     let nested3_level2_group = commands
-        .spawn((
+        .spawn(
             SdfGroup::new(nested3_small_sphere)
-                .difference(nested3_level3_group),
-            SdfTransform::default(),
-        ))
+                .difference(nested3_level3_group)
+                .build(),
+        )
         .id();
 
     // Level 1: nested3_big_sphere - nested3_level2_group
-    commands.spawn((
+    commands.spawn(
         SdfGroup::new(nested3_big_sphere)
-            .difference(nested3_level2_group),
-        SdfTransform::default()
-            .with_translation(Vec3::new(0.0, -1.5, 0.0)),
-    ));
+            .difference(nested3_level2_group)
+            .translate(Vec3::new(0.0, -1.5, 0.0))
+            .build(),
+    );
 
     // Sibling test: (big_sphere - left_sphere) n (big_sphere - right_sphere)
     let left_sphere = commands
         .spawn((
             SdfSphere { radius: 0.5 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(-0.5, 0.0, 0.0)),
+            SdfTransform::from_xyz(-0.5, 0.0, 0.0),
         ))
         .id();
-    let group_left = commands
-        .spawn((SdfGroup::new(left_sphere), SdfTransform::default()))
-        .id();
+
+    let group_left =
+        commands.spawn(SdfGroup::new(left_sphere).build()).id();
 
     let right_sphere = commands
         .spawn((
             SdfSphere { radius: 0.5 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.5, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.5, 0.0, 0.0),
         ))
         .id();
-    let group_right = commands
-        .spawn((SdfGroup::new(right_sphere), SdfTransform::default()))
-        .id();
 
-    let sphere_a = commands
-        .spawn((SdfSphere { radius: 0.5 }, SdfTransform::default()))
-        .id();
+    let group_right =
+        commands.spawn(SdfGroup::new(right_sphere).build()).id();
 
-    commands.spawn((
+    let sphere_a = commands.spawn(SdfSphere { radius: 0.5 }).id();
+
+    commands.spawn(
         SdfGroup::new(sphere_a)
             .difference(group_left)
-            .difference(group_right),
-        SdfTransform::default()
-            .with_translation(Vec3::new(-2.0, 1.5, 0.0)),
-    ));
+            .difference(group_right)
+            .translate(Vec3::new(-2.0, 1.5, 0.0))
+            .build(),
+    );
 
     // Primitive after subgroup ordering test
-    let big_sphere = commands
-        .spawn((SdfSphere { radius: 0.55 }, SdfTransform::default()))
-        .id();
+    let big_sphere = commands.spawn(SdfSphere { radius: 0.55 }).id();
 
     // inner_group: med_sphere − small_sphere
-    let med_sphere = commands
-        .spawn((
-            SdfSphere { radius: 0.35 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.0, 0.0, 0.0)),
-        ))
-        .id();
+    let med_sphere = commands.spawn(SdfSphere { radius: 0.35 }).id();
+
     let small_sphere = commands
         .spawn((
             SdfSphere { radius: 0.2 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.15, 0.0, 0.0)),
+            SdfTransform::from_xyz(0.15, 0.0, 0.0),
         ))
         .id();
+
     let inner_group = commands
-        .spawn((
-            SdfGroup::new(med_sphere).difference(small_sphere),
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.25, 0.0, 0.0)),
-        ))
+        .spawn(
+            SdfGroup::new(med_sphere)
+                .difference(small_sphere)
+                .translate(Vec3::new(0.25, 0.0, 0.0))
+                .build(),
+        )
         .id();
 
     // cap_sphere: (order=2, AFTER subgroup)
     let cap_sphere = commands
         .spawn((
             SdfSphere { radius: 0.45 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.0, 0.35, 0.0)),
+            SdfTransform::from_xyz(0.0, 0.35, 0.0),
         ))
         .id();
 
     // outer_group: big − inner_group − cap
-    commands.spawn((
+    commands.spawn(
         SdfGroup::new(big_sphere)
             .difference(inner_group)
-            .difference(cap_sphere),
-        SdfTransform::default()
-            .with_translation(Vec3::new(2.0, 1.5, 0.0)),
-    ));
+            .difference(cap_sphere)
+            .translate(Vec3::new(2.0, 1.5, 0.0))
+            .build(),
+    );
 }
 
 fn rotate_sdf(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use xad::XadPlugin;
 use xad::camera::CameraController;
 use xad::sdf::SdfCamera;
-use xad::sdf::boolean::SdfGroup;
+use xad::sdf::boolean::{IntoSdfNode, SdfGroup};
 use xad::sdf::primitves::{
     SdfSphere,
     // SdfCapsule,
@@ -39,72 +39,95 @@ fn test_setup(
 
     // Boolean groups
     // Difference: sphere_a - sphere_b
-    let sphere_a = commands
-        .spawn((SdfSphere { radius: 0.6 }, SdfTransform::default()))
-        .id();
-    let sphere_b = commands
-        .spawn((
-            SdfSphere { radius: 0.6 },
+    commands
+        .spawn(
             SdfTransform::default()
-                .with_translation(Vec3::new(0.3, 0.0, 0.0)),
-        ))
-        .id();
-    commands.spawn((
-        SdfGroup::new(sphere_a).difference(sphere_b),
-        SdfTransform::default()
-            .with_translation(Vec3::new(-2.0, 0.0, 0.0)),
-    ));
+                .with_translation(Vec3::new(-2.0, 0.0, 0.0)),
+        )
+        .queue(
+            SdfGroup::new()
+                .add(
+                    (
+                        SdfSphere { radius: 0.6 },
+                        SdfTransform::default(),
+                    )
+                        .union(),
+                )
+                .add(
+                    (
+                        SdfSphere { radius: 0.6 },
+                        SdfTransform::default().with_translation(
+                            Vec3::new(0.3, 0.0, 0.0),
+                        ),
+                    )
+                        .difference(),
+                ),
+        );
 
     // Intersection: sphere_a n sphere_b
-    let sphere_a = commands
-        .spawn((
-            SdfSphere { radius: 0.5 },
+    commands
+        .spawn(
             SdfTransform::default()
-                .with_translation(Vec3::new(-0.2, 0.0, 0.0)),
-        ))
-        .id();
-    let sphere_b = commands
-        .spawn((
-            SdfSphere { radius: 0.5 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.2, 0.0, 0.0)),
-        ))
-        .id();
-    commands.spawn((
-        SdfGroup::new(sphere_a).intersect(sphere_b),
-        SdfTransform::default()
-            .with_translation(Vec3::new(0.0, 0.0, 0.0)),
-    ));
+                .with_translation(Vec3::new(0.0, 0.0, 0.0)),
+        )
+        .queue(
+            SdfGroup::new()
+                .add(
+                    (
+                        SdfSphere { radius: 0.5 },
+                        SdfTransform::default().with_translation(
+                            Vec3::new(-0.2, 0.0, 0.0),
+                        ),
+                    )
+                        .union(),
+                )
+                .add(
+                    (
+                        SdfSphere { radius: 0.5 },
+                        SdfTransform::default().with_translation(
+                            Vec3::new(0.2, 0.0, 0.0),
+                        ),
+                    )
+                        .intersect(),
+                ),
+        );
 
     // Exclusion: (sphere_a XOR sphere_b) - sphere_c
-    let sphere_a = commands
-        .spawn((
-            SdfSphere { radius: 0.45 },
+    commands
+        .spawn(
             SdfTransform::default()
-                .with_translation(Vec3::new(-0.2, 0.0, 0.0)),
-        ))
-        .id();
-    let sphere_b = commands
-        .spawn((
-            SdfSphere { radius: 0.45 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.2, 0.0, 0.0)),
-        ))
-        .id();
-    let sphere_c = commands
-        .spawn((
-            SdfSphere { radius: 0.3 },
-            SdfTransform::default()
-                .with_translation(Vec3::new(0.0, 0.3, 0.0)),
-        ))
-        .id();
-    commands.spawn((
-        SdfGroup::new(sphere_a)
-            .exclude(sphere_b)
-            .difference(sphere_c),
-        SdfTransform::default()
-            .with_translation(Vec3::new(2.0, 0.0, 0.0)),
-    ));
+                .with_translation(Vec3::new(2.0, 0.0, 0.0)),
+        )
+        .queue(
+            SdfGroup::new()
+                .add(
+                    (
+                        SdfSphere { radius: 0.45 },
+                        SdfTransform::default().with_translation(
+                            Vec3::new(-0.2, 0.0, 0.0),
+                        ),
+                    )
+                        .union(),
+                )
+                .add(
+                    (
+                        SdfSphere { radius: 0.45 },
+                        SdfTransform::default().with_translation(
+                            Vec3::new(0.2, 0.0, 0.0),
+                        ),
+                    )
+                        .exclude(),
+                )
+                .add(
+                    (
+                        SdfSphere { radius: 0.3 },
+                        SdfTransform::default().with_translation(
+                            Vec3::new(0.0, 0.3, 0.0),
+                        ),
+                    )
+                        .difference(),
+                ),
+        );
 
     commands.spawn((
         Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(10.0)))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,97 @@ fn test_setup(
         MeshMaterial3d(materials.add(StandardMaterial::default())),
         Transform::default(),
     ));
+
+    // Nested boolean test (2 levels): big_sphere - (medium_sphere - small_sphere)
+    let nested_big_sphere = commands
+        .spawn((SdfSphere { radius: 0.6 }, SdfTransform::default()))
+        .id();
+
+    let nested_medium_sphere = commands
+        .spawn((
+            SdfSphere { radius: 0.45 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.25, 0.0, 0.0)),
+        ))
+        .id();
+
+    let nested_small_sphere = commands
+        .spawn((
+            SdfSphere { radius: 0.25 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.25, 0.0, 0.0)),
+        ))
+        .id();
+
+    let nested_inner_group = commands
+        .spawn((
+            SdfGroup::new(nested_medium_sphere)
+                .difference(nested_small_sphere),
+            SdfTransform::default(),
+        ))
+        .id();
+
+    commands.spawn((
+        SdfGroup::new(nested_big_sphere)
+            .difference(nested_inner_group),
+        SdfTransform::default()
+            .with_translation(Vec3::new(0.0, 1.5, 0.0)),
+    ));
+
+    // Nested boolean test (3 levels): big_sphere - (small_sphere - (tiny_sphere_a - tiny_sphere_b))
+    let nested3_big_sphere = commands
+        .spawn((SdfSphere { radius: 0.6 }, SdfTransform::default()))
+        .id();
+
+    let nested3_small_sphere = commands
+        .spawn((
+            SdfSphere { radius: 0.4 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.4, 0.0, 0.0)),
+        ))
+        .id();
+
+    let nested3_tiny_sphere_a = commands
+        .spawn((
+            SdfSphere { radius: 0.25 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.7, 0.0, 0.0)),
+        ))
+        .id();
+
+    let nested3_tiny_sphere_b = commands
+        .spawn((
+            SdfSphere { radius: 0.12 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.7, 0.0, 0.0)),
+        ))
+        .id();
+
+    // Level 3: nested3_tiny_sphere_a - nested3_tiny_sphere_b
+    let nested3_level3_group = commands
+        .spawn((
+            SdfGroup::new(nested3_tiny_sphere_a)
+                .difference(nested3_tiny_sphere_b),
+            SdfTransform::default(),
+        ))
+        .id();
+
+    // Level 2: nested3_small_sphere - nested3_level3_group
+    let nested3_level2_group = commands
+        .spawn((
+            SdfGroup::new(nested3_small_sphere)
+                .difference(nested3_level3_group),
+            SdfTransform::default(),
+        ))
+        .id();
+
+    // Level 1: nested3_big_sphere - nested3_level2_group
+    commands.spawn((
+        SdfGroup::new(nested3_big_sphere)
+            .difference(nested3_level2_group),
+        SdfTransform::default()
+            .with_translation(Vec3::new(0.0, -1.5, 0.0)),
+    ));
 }
 
 fn rotate_sdf(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use xad::XadPlugin;
 use xad::camera::CameraController;
 use xad::sdf::SdfCamera;
-use xad::sdf::boolean::{IntoSdfNode, SdfGroup};
+use xad::sdf::boolean::{SdfGroup, SdfOperandOf, SdfOperands};
 use xad::sdf::primitves::{
     SdfSphere,
     // SdfCapsule,
@@ -39,95 +39,71 @@ fn test_setup(
 
     // Boolean groups
     // Difference: sphere_a - sphere_b
-    commands
-        .spawn(
+    let sphere_a = commands
+        .spawn((SdfSphere { radius: 0.6 }, SdfTransform::default()))
+        .id();
+    let sphere_b = commands
+        .spawn((
+            SdfSphere { radius: 0.6 },
             SdfTransform::default()
-                .with_translation(Vec3::new(-2.0, 0.0, 0.0)),
-        )
-        .queue(
-            SdfGroup::new()
-                .add(
-                    (
-                        SdfSphere { radius: 0.6 },
-                        SdfTransform::default(),
-                    )
-                        .union(),
-                )
-                .add(
-                    (
-                        SdfSphere { radius: 0.6 },
-                        SdfTransform::default().with_translation(
-                            Vec3::new(0.3, 0.0, 0.0),
-                        ),
-                    )
-                        .difference(),
-                ),
-        );
+                .with_translation(Vec3::new(0.3, 0.0, 0.0)),
+        ))
+        .id();
+    commands.spawn((
+        SdfGroup::new(sphere_a).difference(sphere_b),
+        SdfTransform::default()
+            .with_translation(Vec3::new(-2.0, 0.0, 0.0)),
+    ));
 
     // Intersection: sphere_a n sphere_b
-    commands
-        .spawn(
+    let sphere_a = commands
+        .spawn((
+            SdfSphere { radius: 0.5 },
             SdfTransform::default()
-                .with_translation(Vec3::new(0.0, 0.0, 0.0)),
-        )
-        .queue(
-            SdfGroup::new()
-                .add(
-                    (
-                        SdfSphere { radius: 0.5 },
-                        SdfTransform::default().with_translation(
-                            Vec3::new(-0.2, 0.0, 0.0),
-                        ),
-                    )
-                        .union(),
-                )
-                .add(
-                    (
-                        SdfSphere { radius: 0.5 },
-                        SdfTransform::default().with_translation(
-                            Vec3::new(0.2, 0.0, 0.0),
-                        ),
-                    )
-                        .intersect(),
-                ),
-        );
+                .with_translation(Vec3::new(-0.2, 0.0, 0.0)),
+        ))
+        .id();
+    let sphere_b = commands
+        .spawn((
+            SdfSphere { radius: 0.5 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.2, 0.0, 0.0)),
+        ))
+        .id();
+    commands.spawn((
+        SdfGroup::new(sphere_a).intersect(sphere_b),
+        SdfTransform::default(),
+    ));
 
     // Exclusion: (sphere_a XOR sphere_b) - sphere_c
-    commands
-        .spawn(
+    let sphere_a = commands
+        .spawn((
+            SdfSphere { radius: 0.45 },
             SdfTransform::default()
-                .with_translation(Vec3::new(2.0, 0.0, 0.0)),
-        )
-        .queue(
-            SdfGroup::new()
-                .add(
-                    (
-                        SdfSphere { radius: 0.45 },
-                        SdfTransform::default().with_translation(
-                            Vec3::new(-0.2, 0.0, 0.0),
-                        ),
-                    )
-                        .union(),
-                )
-                .add(
-                    (
-                        SdfSphere { radius: 0.45 },
-                        SdfTransform::default().with_translation(
-                            Vec3::new(0.2, 0.0, 0.0),
-                        ),
-                    )
-                        .exclude(),
-                )
-                .add(
-                    (
-                        SdfSphere { radius: 0.3 },
-                        SdfTransform::default().with_translation(
-                            Vec3::new(0.0, 0.3, 0.0),
-                        ),
-                    )
-                        .difference(),
-                ),
-        );
+                .with_translation(Vec3::new(-0.2, 0.0, 0.0)),
+        ))
+        .id();
+    let sphere_b = commands
+        .spawn((
+            SdfSphere { radius: 0.45 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.2, 0.0, 0.0)),
+        ))
+        .id();
+    let sphere_c = commands
+        .spawn((
+            SdfSphere { radius: 0.3 },
+            SdfTransform::default()
+                .with_translation(Vec3::new(0.0, 0.3, 0.0)),
+        ))
+        .id();
+    commands.spawn((
+        SdfGroup::new(sphere_a)
+            .exclude(sphere_b)
+            .difference(sphere_c),
+        SdfTransform::default()
+            .with_translation(Vec3::new(2.0, 0.0, 0.0)),
+    ));
 
     commands.spawn((
         Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(10.0)))),
@@ -137,7 +113,10 @@ fn test_setup(
 }
 
 fn rotate_sdf(
-    mut q_transforms: Query<&mut SdfTransform>,
+    mut q_transforms: Query<
+        &mut SdfTransform,
+        (With<SdfOperands>, Without<SdfOperandOf>),
+    >,
     time: Res<Time>,
 ) {
     for (i, mut transform) in q_transforms.iter_mut().enumerate() {

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -254,18 +254,32 @@ fn update_input_buffers(
         &PrimitiveIndex,
         Option<&SdfExtractedOperand>,
     )>,
+    q_changed: Query<
+        (),
+        Or<(
+            Changed<SdfGlobalTransform>,
+            Changed<PrimitiveIndex>,
+            Added<PrimitiveIndex>,
+        )>,
+    >,
     mut buffers: ResMut<SdfBuffers>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
     // TODO: Optimize this to only update changed/added/removed transform!
+    if q_changed.is_empty() {
+        return;
+    }
+
     buffers.input_buffer.clear();
 
-    let mut group_id_map: HashMap<Entity, u32> = HashMap::default();
+    let count = q_primitives.iter().len();
+    let mut group_id_map: HashMap<Entity, u32> =
+        HashMap::with_capacity(count);
     let mut next_id: u32 = 1;
 
-    let mut sorted_inputs =
-        Vec::with_capacity(q_primitives.iter().len());
+    let mut sorted_inputs: Vec<(u32, usize, SdfInput)> =
+        Vec::with_capacity(count);
 
     for (transform, ty, index, operand_opt) in q_primitives.iter() {
         let (group_id, order, op) = if let Some(operand) = operand_opt
@@ -311,12 +325,20 @@ fn update_primitive_buffers<
     InMut((ty, get_buffer)): InMut<(PrimitiveType, F)>,
     mut commands: Commands,
     q_primitives: Query<(&T, Entity)>,
+    q_changed: Query<(), Or<(Changed<T>, Added<T>)>>,
+    removed: RemovedComponents<T>,
     mut buffers: ResMut<SdfBuffers>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
     // TODO: Optimize this to only update changed/added/removed primitive!
     let buffer = get_buffer(&mut buffers);
+
+    if q_changed.is_empty() && removed.is_empty() && buffer.len() > 1
+    {
+        return;
+    }
+
     buffer.clear();
     // TODO: This could be replaced with a custom self managed empty buffer
     // next time. (This is needed right now since a `BufferVec` won't be created

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -1,6 +1,7 @@
 use bevy::core_pipeline::FullscreenShader;
 use bevy::core_pipeline::core_3d::graph::{Core3d, Node3d};
 use bevy::ecs::query::QueryItem;
+use bevy::ecs::system::SystemParam;
 use bevy::ecs::system::lifetimeless::Read;
 use bevy::math::Affine3;
 use bevy::prelude::*;
@@ -35,6 +36,31 @@ use crate::sdf::transform::{SdfGlobalTransform, SdfTransformPlugin};
 pub mod boolean;
 pub mod primitves;
 pub mod transform;
+
+/// Filter for operands whose relationship or ordering changed.
+type ChangedOperandFilter = Or<(
+    Changed<SdfOperandOf>,
+    Changed<SdfBooleanOp>,
+    Changed<SdfOrder>,
+)>;
+
+/// Filter used to detect any render-relevant change in the input buffer.
+type AnyInputChanged = Or<(
+    Changed<SdfGlobalTransform>,
+    Changed<PrimitiveIndex>,
+    Added<PrimitiveIndex>,
+    Changed<SdfExtractedOperand>,
+)>;
+
+/// Filter used to detect a changed or newly-added primitive component.
+type PrimitiveChanged<T> = Or<(Changed<T>, Added<T>)>;
+
+/// [`RenderDevice`] and [`RenderQueue`] grouped.
+#[derive(SystemParam)]
+struct RenderResources<'w> {
+    device: Res<'w, RenderDevice>,
+    queue: Res<'w, RenderQueue>,
+}
 
 const SHADER_ASSET_PATH: &str = "shaders/sdf_raymarch.wgsl";
 
@@ -267,11 +293,7 @@ fn extract_sdf_operands(
     q_changed_operands: Extract<
         Query<
             (&RenderEntity, &SdfOperandOf, &SdfBooleanOp, &SdfOrder),
-            Or<(
-                Changed<SdfOperandOf>,
-                Changed<SdfBooleanOp>,
-                Changed<SdfOrder>,
-            )>,
+            ChangedOperandFilter,
         >,
     >,
     mut removed: Extract<RemovedComponents<SdfOperandOf>>,
@@ -382,20 +404,11 @@ fn update_input_buffers(
         Option<&SdfExtractedOperand>,
     )>,
     q_group_operands: Query<(&SdfExtractedOperand, &MainEntity)>,
-    q_changed: Query<
-        (),
-        Or<(
-            Changed<SdfGlobalTransform>,
-            Changed<PrimitiveIndex>,
-            Added<PrimitiveIndex>,
-            Changed<SdfExtractedOperand>,
-        )>,
-    >,
+    q_changed: Query<(), AnyInputChanged>,
     removed_primitives: RemovedComponents<PrimitiveIndex>,
     removed_operands: RemovedComponents<SdfExtractedOperand>,
     mut buffers: ResMut<SdfBuffers>,
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
+    render: RenderResources,
 ) {
     // TODO: Optimize this to only update changed/added/removed transform!
     if q_changed.is_empty()
@@ -496,7 +509,7 @@ fn update_input_buffers(
     }
     buffers
         .input_buffer
-        .write_buffer(&render_device, &render_queue);
+        .write_buffer(&render.device, &render.queue);
 }
 
 fn update_primitive_buffers<
@@ -506,11 +519,10 @@ fn update_primitive_buffers<
     InMut((ty, get_buffer)): InMut<(PrimitiveType, F)>,
     mut commands: Commands,
     q_primitives: Query<(&T, Entity, Option<&PrimitiveIndex>)>,
-    q_changed: Query<(), Or<(Changed<T>, Added<T>)>>,
+    q_changed: Query<(), PrimitiveChanged<T>>,
     removed: RemovedComponents<T>,
     mut buffers: ResMut<SdfBuffers>,
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
+    render: RenderResources,
 ) {
     // TODO: Optimize this to only update changed/added/removed primitive!
     let buffer = get_buffer(&mut buffers);
@@ -541,7 +553,7 @@ fn update_primitive_buffers<
         }
     }
 
-    buffer.write_buffer(&render_device, &render_queue);
+    buffer.write_buffer(&render.device, &render.queue);
 }
 
 fn init_sdf_buffers(mut commands: Commands) {

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -16,8 +16,11 @@ use bevy::render::view::{
     ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
 };
 use bevy::render::{Render, RenderApp, RenderStartup, RenderSystems};
+use std::collections::HashMap;
 
-use crate::sdf::boolean::{BooleanOp, SdfBooleanPlugin, SdfOperand};
+use crate::sdf::boolean::{
+    BooleanOp, SdfBooleanPlugin, SdfExtractedOperand,
+};
 use crate::sdf::primitves::{
     SdfCapsule, SdfCuboid, SdfPrimitivePlugin, SdfRoundCuboid,
     SdfSphere, SdfTorus,
@@ -249,7 +252,7 @@ fn update_input_buffers(
         &SdfGlobalTransform,
         &PrimitiveType,
         &PrimitiveIndex,
-        Option<&SdfOperand>,
+        Option<&SdfExtractedOperand>,
     )>,
     mut buffers: ResMut<SdfBuffers>,
     render_device: Res<RenderDevice>,
@@ -258,37 +261,34 @@ fn update_input_buffers(
     // TODO: Optimize this to only update changed/added/removed transform!
     buffers.input_buffer.clear();
 
+    let mut group_id_map: HashMap<Entity, u32> = HashMap::default();
+    let mut next_id: u32 = 1;
+
     let mut sorted_inputs =
         Vec::with_capacity(q_primitives.iter().len());
 
     for (transform, ty, index, operand_opt) in q_primitives.iter() {
-        if let Some(operand) = operand_opt {
+        let (group_id, order, op) = if let Some(operand) = operand_opt
+        {
             // Grouped primitive
-            sorted_inputs.push((
-                operand.group_id,
-                operand.order,
-                SdfInput::new(
-                    transform,
-                    ty,
-                    index,
-                    operand.group_id,
-                    operand.op as u32,
-                ),
-            ));
+            let gid = *group_id_map
+                .entry(operand.group_entity)
+                .or_insert_with(|| {
+                    let id = next_id;
+                    next_id += 1;
+                    id
+                });
+            (gid, operand.order, operand.op as u32)
         } else {
             // Ungrouped primitive
-            sorted_inputs.push((
-                0,
-                0,
-                SdfInput::new(
-                    transform,
-                    ty,
-                    index,
-                    0,
-                    BooleanOp::Union as u32,
-                ),
-            ));
-        }
+            (0, 0, BooleanOp::Union as u32)
+        };
+
+        sorted_inputs.push((
+            group_id,
+            order,
+            SdfInput::new(transform, ty, index, group_id, op),
+        ));
     }
 
     sorted_inputs.sort_unstable_by_key(|(g, o, _)| (*g, *o));

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -12,11 +12,12 @@ use bevy::render::render_resource::*;
 use bevy::render::renderer::{
     RenderContext, RenderDevice, RenderQueue,
 };
+use bevy::render::sync_world::MainEntity;
 use bevy::render::view::{
     ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
 };
 use bevy::render::{Render, RenderApp, RenderStartup, RenderSystems};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::sdf::boolean::{
     BooleanOp, SdfBooleanPlugin, SdfExtractedOperand,
@@ -254,6 +255,7 @@ fn update_input_buffers(
         &PrimitiveIndex,
         Option<&SdfExtractedOperand>,
     )>,
+    q_group_operands: Query<(&SdfExtractedOperand, &MainEntity)>,
     q_changed: Query<
         (),
         Or<(
@@ -273,35 +275,110 @@ fn update_input_buffers(
 
     buffers.input_buffer.clear();
 
-    let count = q_primitives.iter().len();
-    let mut group_id_map: HashMap<Entity, u32> =
-        HashMap::with_capacity(count);
-    let mut next_id: u32 = 1;
+    let operand_count = q_group_operands.iter().len();
+    let mut group_entities: HashSet<Entity> =
+        HashSet::with_capacity(operand_count);
+    let mut operand_of: HashMap<Entity, &SdfExtractedOperand> =
+        HashMap::with_capacity(operand_count);
 
-    let mut sorted_inputs: Vec<(u32, usize, SdfInput)> =
-        Vec::with_capacity(count);
+    for (operand, main_entity) in q_group_operands.iter() {
+        group_entities.insert(operand.group_entity);
+        operand_of.insert(main_entity.id(), operand);
+    }
+
+    // Build a map of group entity to its group children, excluding primitive operands.
+    // This will be used to perform a DFS and assign group ids.
+    let mut children_of: HashMap<Entity, Vec<(usize, Entity)>> =
+        HashMap::with_capacity(group_entities.len());
+    for (&child, operand) in &operand_of {
+        if group_entities.contains(&child) {
+            children_of
+                .entry(operand.group_entity)
+                .or_default()
+                .push((operand.order, child));
+        }
+    }
+    // Ensure siblings are visited in SdfOrder during DFS.
+    for v in children_of.values_mut() {
+        v.sort_unstable_by_key(|&(order, _)| order);
+    }
+
+    // Root groups that are not a child of any other group.
+    let mut roots: Vec<Entity> = group_entities
+        .iter()
+        .filter(|g| !operand_of.contains_key(g))
+        .copied()
+        .collect();
+    roots.sort_unstable();
+
+    // Assign group ids based on DFS order.
+    // This ensures that parent groups always have smaller group ids than their children.
+    let mut group_id_map: HashMap<Entity, u32> =
+        HashMap::with_capacity(group_entities.len());
+    let mut next_id: u32 = 1;
+    let mut dfs: Vec<Entity> = roots.into_iter().rev().collect();
+    while let Some(group) = dfs.pop() {
+        group_id_map.insert(group, next_id);
+        next_id += 1;
+        if let Some(children) = children_of.get(&group) {
+            for &(_, child) in children.iter().rev() {
+                dfs.push(child);
+            }
+        }
+    }
+
+    let mut sorted_inputs: Vec<(u32, usize, SdfInput)> = Vec::new();
 
     for (transform, ty, index, operand_opt) in q_primitives.iter() {
-        let (group_id, order, op) = if let Some(operand) = operand_opt
-        {
-            // Grouped primitive
-            let gid = *group_id_map
-                .entry(operand.group_entity)
-                .or_insert_with(|| {
-                    let id = next_id;
-                    next_id += 1;
-                    id
-                });
-            (gid, operand.order, operand.op as u32)
-        } else {
-            // Ungrouped primitive
-            (0, 0, BooleanOp::Union as u32)
-        };
+        let (group_id, order, op, parent_group_id, parent_op) =
+            if let Some(operand) = operand_opt {
+                let gid = group_id_map
+                    .get(&operand.group_entity)
+                    .copied()
+                    .unwrap_or(0);
+
+                let (parent_gid, par_op) =
+                    if let Some(group_operand) =
+                        operand_of.get(&operand.group_entity)
+                    {
+                        let pgid = group_id_map
+                            .get(&group_operand.group_entity)
+                            .copied()
+                            .unwrap_or(0);
+                        (pgid, group_operand.op as u32)
+                    } else {
+                        (0, BooleanOp::Union as u32)
+                    };
+
+                (
+                    gid,
+                    operand.order,
+                    operand.op as u32,
+                    parent_gid,
+                    par_op,
+                )
+            } else {
+                (
+                    0,
+                    0,
+                    BooleanOp::Union as u32,
+                    0,
+                    BooleanOp::Union as u32,
+                )
+            };
 
         sorted_inputs.push((
             group_id,
             order,
-            SdfInput::new(transform, ty, index, group_id, op),
+            SdfInput::new(
+                transform,
+                ty,
+                index,
+                group_id,
+                op,
+                parent_group_id,
+                parent_op,
+            ),
         ));
     }
 
@@ -510,6 +587,8 @@ struct SdfInput {
     pub primitive_index: u32,
     pub group_id: u32,
     pub boolean_op: u32,
+    pub parent_group_id: u32,
+    pub parent_op: u32,
 }
 
 impl SdfInput {
@@ -519,6 +598,8 @@ impl SdfInput {
         index: &PrimitiveIndex,
         group_id: u32,
         boolean_op: u32,
+        parent_group_id: u32,
+        parent_op: u32,
     ) -> Self {
         Self {
             local_from_world: Affine3::from(
@@ -532,6 +613,8 @@ impl SdfInput {
             primitive_index: index.0 + 1,
             group_id,
             boolean_op,
+            parent_group_id,
+            parent_op,
         }
     }
 }

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -12,15 +12,19 @@ use bevy::render::render_resource::*;
 use bevy::render::renderer::{
     RenderContext, RenderDevice, RenderQueue,
 };
-use bevy::render::sync_world::MainEntity;
+use bevy::render::sync_world::{MainEntity, RenderEntity};
 use bevy::render::view::{
     ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
 };
-use bevy::render::{Render, RenderApp, RenderStartup, RenderSystems};
+use bevy::render::{
+    Extract, ExtractSchedule, Render, RenderApp, RenderStartup,
+    RenderSystems,
+};
 use std::collections::{HashMap, HashSet};
 
 use crate::sdf::boolean::{
-    BooleanOp, SdfBooleanPlugin, SdfExtractedOperand,
+    BooleanOp, SdfBooleanOp, SdfBooleanPlugin, SdfExtractedOperand,
+    SdfOperandOf, SdfOrder,
 };
 use crate::sdf::primitves::{
     SdfCapsule, SdfCuboid, SdfPrimitivePlugin, SdfRoundCuboid,
@@ -51,6 +55,7 @@ impl Plugin for SdfPlugin {
         };
 
         render_app
+            .add_systems(ExtractSchedule, extract_sdf_operands)
             .add_systems(
                 RenderStartup,
                 (init_sdf_pipeline, init_sdf_buffers),
@@ -248,6 +253,34 @@ struct SdfBuffers {
     torus_buffer: BufferVec<SdfTorus>,
 }
 
+/// Extracts [`SdfExtractedOperand`] for all operand entities into the render world.
+///
+/// Using [`Changed`] on the main-world components gives correct first-insertion detection
+/// without spuriously triggering every frame.
+fn extract_sdf_operands(
+    q: Extract<
+        Query<
+            (&RenderEntity, &SdfOperandOf, &SdfBooleanOp, &SdfOrder),
+            Or<(
+                Changed<SdfOperandOf>,
+                Changed<SdfBooleanOp>,
+                Changed<SdfOrder>,
+            )>,
+        >,
+    >,
+    mut commands: Commands,
+) {
+    for (render_entity, operand_of, bool_op, order) in q.iter() {
+        commands.entity(render_entity.id()).insert(
+            SdfExtractedOperand {
+                group_entity: operand_of.0,
+                op: bool_op.0,
+                order: order.0,
+            },
+        );
+    }
+}
+
 fn update_input_buffers(
     q_primitives: Query<(
         &SdfGlobalTransform,
@@ -411,7 +444,9 @@ fn update_primitive_buffers<
     // TODO: Optimize this to only update changed/added/removed primitive!
     let buffer = get_buffer(&mut buffers);
 
-    if q_changed.is_empty() && removed.is_empty() && buffer.len() > 1
+    if q_changed.is_empty()
+        && removed.is_empty()
+        && !buffer.is_empty()
     {
         return;
     }

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -264,7 +264,7 @@ struct SdfBuffers {
 /// Using [`Changed`] on the main-world components gives correct first-insertion detection
 /// without spuriously triggering every frame.
 fn extract_sdf_operands(
-    q: Extract<
+    q_changed_operands: Extract<
         Query<
             (&RenderEntity, &SdfOperandOf, &SdfBooleanOp, &SdfOrder),
             Or<(
@@ -274,9 +274,13 @@ fn extract_sdf_operands(
             )>,
         >,
     >,
+    mut removed: Extract<RemovedComponents<SdfOperandOf>>,
+    render_entities: Extract<Query<&RenderEntity>>,
     mut commands: Commands,
 ) {
-    for (render_entity, operand_of, bool_op, order) in q.iter() {
+    for (render_entity, operand_of, bool_op, order) in
+        q_changed_operands.iter()
+    {
         commands.entity(render_entity.id()).insert(
             SdfExtractedOperand {
                 group_entity: operand_of.0,
@@ -284,6 +288,14 @@ fn extract_sdf_operands(
                 order: order.0,
             },
         );
+    }
+
+    for main_entity in removed.read() {
+        if let Ok(render_entity) = render_entities.get(main_entity) {
+            commands
+                .entity(render_entity.id())
+                .remove::<SdfExtractedOperand>();
+        }
     }
 }
 

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -287,6 +287,81 @@ fn extract_sdf_operands(
     }
 }
 
+/// Emit one group into the packed buffer in preorder.
+///
+/// By emitting the group header before recursing into children, the header's
+/// buffer position becomes its stable, unique identity.  Every child record
+/// carries `parent_index` = that position, so the shader can detect group
+/// boundaries purely from `parent_index` mismatches.
+fn emit_group(
+    group: Entity,
+    parent_header_index: u32,
+    boolean_op: u32,
+    primitives_of: &HashMap<Entity, Vec<(usize, SdfInput)>>,
+    children_of: &HashMap<Entity, Vec<(usize, Entity, u32)>>,
+    buffer: &mut BufferVec<SdfInput>,
+) -> bool {
+    // Save position so it can roll back if this group turns out to be empty.
+    let start = buffer.len();
+    let header_index = start as u32;
+
+    // Emit group header, rolled back below if no children follow.
+    buffer.push(SdfInput {
+        has_children: 1,
+        boolean_op,
+        parent_index: parent_header_index,
+        ..SdfInput::default()
+    });
+
+    // Build and sort slots by SdfOrder
+    // Interleave direct-primitive slots and subgroup slots respecting user order.
+    let prim_count = primitives_of.get(&group).map_or(0, |v| v.len());
+    let child_count = children_of.get(&group).map_or(0, |v| v.len());
+    let mut slots: Vec<(usize, bool, usize)> =
+        Vec::with_capacity(prim_count + child_count);
+
+    if let Some(prims) = primitives_of.get(&group) {
+        for (i, &(order, _)) in prims.iter().enumerate() {
+            slots.push((order, false, i));
+        }
+    }
+    if let Some(children) = children_of.get(&group) {
+        for (i, &(order, _, _)) in children.iter().enumerate() {
+            slots.push((order, true, i));
+        }
+    }
+    slots.sort_unstable_by_key(|&(order, _, _)| order);
+
+    // Emit children in order
+    for (_, is_sub, idx) in slots {
+        if is_sub {
+            let (_, child, child_op) = children_of[&group][idx];
+            // Recursive call returns false and self-truncates if child is empty.
+            emit_group(
+                child,
+                header_index, // child's parent is this group's header
+                child_op,
+                primitives_of,
+                children_of,
+                buffer,
+            );
+        } else {
+            // Leaf primitive, stamp the real parent_index before emitting.
+            let mut input = primitives_of[&group][idx].1;
+            input.parent_index = header_index;
+            buffer.push(input);
+        }
+    }
+
+    // If nothing was added beyond the header, roll back entirely.
+    if buffer.len() == start + 1 {
+        buffer.truncate(start);
+        return false;
+    }
+
+    true
+}
+
 fn update_input_buffers(
     q_primitives: Query<(
         &SdfGlobalTransform,
@@ -329,24 +404,61 @@ fn update_input_buffers(
         operand_of.insert(main_entity.id(), operand);
     }
 
-    // Build a map of group entity to its group children, excluding primitive operands.
-    // This will be used to perform a DFS and assign group ids.
-    let mut children_of: HashMap<Entity, Vec<(usize, Entity)>> =
+    // Stores only entities that are themselves groups (not leaf primitives).
+    let mut children_of: HashMap<Entity, Vec<(usize, Entity, u32)>> =
         HashMap::with_capacity(group_entities.len());
     for (&child, operand) in &operand_of {
         if group_entities.contains(&child) {
             children_of
                 .entry(operand.group_entity)
                 .or_default()
-                .push((operand.order, child));
+                .push((operand.order, child, operand.op as u32));
         }
     }
-    // Ensure siblings are visited in SdfOrder during DFS.
     for v in children_of.values_mut() {
+        v.sort_unstable_by_key(|&(order, _, _)| order);
+    }
+
+    // Collect primitives per group.
+    let mut primitives_of: HashMap<Entity, Vec<(usize, SdfInput)>> =
+        HashMap::new();
+
+    for (transform, ty, index, operand_opt) in q_primitives.iter() {
+        match operand_opt {
+            None => {
+                // Root-level primitive, lives directly in the scene, no parent group.
+                buffers.input_buffer.push(SdfInput::new(
+                    transform,
+                    ty,
+                    index,
+                    BooleanOp::Union as u32,
+                    u32::MAX, // no parent group
+                ));
+            }
+            Some(operand) => {
+                // Grouped primitive, parent_index will be patched.
+                primitives_of
+                    .entry(operand.group_entity)
+                    .or_default()
+                    .push((
+                        operand.order,
+                        SdfInput::new(
+                            transform,
+                            ty,
+                            index,
+                            operand.op as u32,
+                            0, // placeholder, patched in emit_group
+                        ),
+                    ));
+            }
+        }
+    }
+
+    for v in primitives_of.values_mut() {
         v.sort_unstable_by_key(|&(order, _)| order);
     }
 
-    // Root groups that are not a child of any other group.
+    // Emit root groups that are not a child of any other group.
     let mut roots: Vec<Entity> = group_entities
         .iter()
         .filter(|g| !operand_of.contains_key(g))
@@ -354,81 +466,15 @@ fn update_input_buffers(
         .collect();
     roots.sort_unstable();
 
-    // Assign group ids based on DFS order.
-    // This ensures that parent groups always have smaller group ids than their children.
-    let mut group_id_map: HashMap<Entity, u32> =
-        HashMap::with_capacity(group_entities.len());
-    let mut next_id: u32 = 1;
-    let mut dfs: Vec<Entity> = roots.into_iter().rev().collect();
-    while let Some(group) = dfs.pop() {
-        group_id_map.insert(group, next_id);
-        next_id += 1;
-        if let Some(children) = children_of.get(&group) {
-            for &(_, child) in children.iter().rev() {
-                dfs.push(child);
-            }
-        }
-    }
-
-    let mut sorted_inputs: Vec<(u32, usize, SdfInput)> = Vec::new();
-
-    for (transform, ty, index, operand_opt) in q_primitives.iter() {
-        let (group_id, order, op, parent_group_id, parent_op) =
-            if let Some(operand) = operand_opt {
-                let gid = group_id_map
-                    .get(&operand.group_entity)
-                    .copied()
-                    .unwrap_or(0);
-
-                let (parent_gid, par_op) =
-                    if let Some(group_operand) =
-                        operand_of.get(&operand.group_entity)
-                    {
-                        let pgid = group_id_map
-                            .get(&group_operand.group_entity)
-                            .copied()
-                            .unwrap_or(0);
-                        (pgid, group_operand.op as u32)
-                    } else {
-                        (0, BooleanOp::Union as u32)
-                    };
-
-                (
-                    gid,
-                    operand.order,
-                    operand.op as u32,
-                    parent_gid,
-                    par_op,
-                )
-            } else {
-                (
-                    0,
-                    0,
-                    BooleanOp::Union as u32,
-                    0,
-                    BooleanOp::Union as u32,
-                )
-            };
-
-        sorted_inputs.push((
-            group_id,
-            order,
-            SdfInput::new(
-                transform,
-                ty,
-                index,
-                group_id,
-                op,
-                parent_group_id,
-                parent_op,
-            ),
-        ));
-    }
-
-    sorted_inputs.sort_unstable_by_key(|(g, o, _)| (*g, *o));
-
-    for (_, _, input) in sorted_inputs {
-        buffers.input_buffer.push(input);
+    for root in roots {
+        emit_group(
+            root,
+            u32::MAX,
+            BooleanOp::Union as u32,
+            &primitives_of,
+            &children_of,
+            &mut buffers.input_buffer,
+        );
     }
 
     buffers.input_count = buffers.input_buffer.len() as u32;
@@ -641,10 +687,12 @@ struct SdfInput {
     pub scale: f32,
     pub primitive_type: u32,
     pub primitive_index: u32,
-    pub group_id: u32,
+    /// Boolean op this record applies to its parent's accumulator.
     pub boolean_op: u32,
-    pub parent_group_id: u32,
-    pub parent_op: u32,
+    /// Buffer index of this record's parent group header.
+    pub parent_index: u32,
+    /// `1` if this record is a group header; `0` if it is a leaf primitive.
+    pub has_children: u32,
 }
 
 impl SdfInput {
@@ -652,10 +700,8 @@ impl SdfInput {
         global_transform: &SdfGlobalTransform,
         ty: &PrimitiveType,
         index: &PrimitiveIndex,
-        group_id: u32,
         boolean_op: u32,
-        parent_group_id: u32,
-        parent_op: u32,
+        parent_index: u32,
     ) -> Self {
         Self {
             local_from_world: Affine3::from(
@@ -667,10 +713,9 @@ impl SdfInput {
             // Index 0 is for default value.
             // TODO: We could cache only primitives with different settings?
             primitive_index: index.0 + 1,
-            group_id,
             boolean_op,
-            parent_group_id,
-            parent_op,
+            parent_index,
+            has_children: 0,
         }
     }
 }

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -299,12 +299,16 @@ fn update_input_buffers(
         )>,
     >,
     removed_primitives: RemovedComponents<PrimitiveIndex>,
+    removed_operands: RemovedComponents<SdfExtractedOperand>,
     mut buffers: ResMut<SdfBuffers>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
     // TODO: Optimize this to only update changed/added/removed transform!
-    if q_changed.is_empty() && removed_primitives.is_empty() {
+    if q_changed.is_empty()
+        && removed_primitives.is_empty()
+        && removed_operands.is_empty()
+    {
         return;
     }
 

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -139,6 +139,11 @@ impl ViewNode for SdfNode {
         let pipeline_cache = world.resource::<PipelineCache>();
         let sdf_pipeline = world.resource::<SdfPipeline>();
         let sdf_buffers = world.resource::<SdfBuffers>();
+
+        if sdf_buffers.input_count == 0 {
+            return Ok(());
+        }
+
         let view_uniforms = world.resource::<ViewUniforms>();
         let sdf_cameras =
             world.resource::<ComponentUniforms<SdfCamera>>();
@@ -251,6 +256,7 @@ struct SdfBuffers {
     round_cuboid_buffer: BufferVec<SdfRoundCuboid>,
     capsule_buffer: BufferVec<SdfCapsule>,
     torus_buffer: BufferVec<SdfTorus>,
+    input_count: u32,
 }
 
 /// Extracts [`SdfExtractedOperand`] for all operand entities into the render world.
@@ -425,11 +431,14 @@ fn update_input_buffers(
         buffers.input_buffer.push(input);
     }
 
-    if !buffers.input_buffer.is_empty() {
-        buffers
-            .input_buffer
-            .write_buffer(&render_device, &render_queue);
+    buffers.input_count = buffers.input_buffer.len() as u32;
+
+    if buffers.input_buffer.is_empty() {
+        buffers.input_buffer.push(SdfInput::default());
     }
+    buffers
+        .input_buffer
+        .write_buffer(&render_device, &render_queue);
 }
 
 fn update_primitive_buffers<
@@ -508,6 +517,7 @@ fn init_sdf_buffers(mut commands: Commands) {
         round_cuboid_buffer,
         capsule_buffer,
         torus_buffer,
+        input_count: 0,
     });
 }
 

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -44,6 +44,19 @@ type ChangedOperandFilter = Or<(
     Changed<SdfOrder>,
 )>;
 
+/// Query for extracting operands whose relationship or ordering changed into the render world.
+type ChangedOperandQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        &'static RenderEntity,
+        &'static SdfOperandOf,
+        &'static SdfBooleanOp,
+        &'static SdfOrder,
+    ),
+    ChangedOperandFilter,
+>;
+
 /// Filter used to detect any render-relevant change in the input buffer.
 type AnyInputChanged = Or<(
     Changed<SdfGlobalTransform>,
@@ -290,12 +303,7 @@ struct SdfBuffers {
 /// Using [`Changed`] on the main-world components gives correct first-insertion detection
 /// without spuriously triggering every frame.
 fn extract_sdf_operands(
-    q_changed_operands: Extract<
-        Query<
-            (&RenderEntity, &SdfOperandOf, &SdfBooleanOp, &SdfOrder),
-            ChangedOperandFilter,
-        >,
-    >,
+    q_changed_operands: Extract<ChangedOperandQuery>,
     mut removed: Extract<RemovedComponents<SdfOperandOf>>,
     render_entities: Extract<Query<&RenderEntity>>,
     mut commands: Commands,

--- a/src/sdf.rs
+++ b/src/sdf.rs
@@ -262,24 +262,24 @@ fn update_input_buffers(
             Changed<SdfGlobalTransform>,
             Changed<PrimitiveIndex>,
             Added<PrimitiveIndex>,
+            Changed<SdfExtractedOperand>,
         )>,
     >,
+    removed_primitives: RemovedComponents<PrimitiveIndex>,
     mut buffers: ResMut<SdfBuffers>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
     // TODO: Optimize this to only update changed/added/removed transform!
-    if q_changed.is_empty() {
+    if q_changed.is_empty() && removed_primitives.is_empty() {
         return;
     }
 
     buffers.input_buffer.clear();
 
-    let operand_count = q_group_operands.iter().len();
-    let mut group_entities: HashSet<Entity> =
-        HashSet::with_capacity(operand_count);
+    let mut group_entities: HashSet<Entity> = HashSet::new();
     let mut operand_of: HashMap<Entity, &SdfExtractedOperand> =
-        HashMap::with_capacity(operand_count);
+        HashMap::new();
 
     for (operand, main_entity) in q_group_operands.iter() {
         group_entities.insert(operand.group_entity);
@@ -401,7 +401,7 @@ fn update_primitive_buffers<
 >(
     InMut((ty, get_buffer)): InMut<(PrimitiveType, F)>,
     mut commands: Commands,
-    q_primitives: Query<(&T, Entity)>,
+    q_primitives: Query<(&T, Entity, Option<&PrimitiveIndex>)>,
     q_changed: Query<(), Or<(Changed<T>, Added<T>)>>,
     removed: RemovedComponents<T>,
     mut buffers: ResMut<SdfBuffers>,
@@ -421,11 +421,18 @@ fn update_primitive_buffers<
     // next time. (This is needed right now since a `BufferVec` won't be created
     // if the data is empty!)
     buffer.push(T::default());
-    for (i, (primitive, entity)) in q_primitives.iter().enumerate() {
+    for (i, (primitive, entity, existing_index)) in
+        q_primitives.iter().enumerate()
+    {
         buffer.push(primitive.clone());
-        commands
-            .entity(entity)
-            .insert((*ty, PrimitiveIndex(i as u32)));
+        // Only insert PrimitiveIndex when it actually changed.
+        if existing_index.map(|idx: &PrimitiveIndex| idx.0)
+            != Some(i as u32)
+        {
+            commands
+                .entity(entity)
+                .insert((*ty, PrimitiveIndex(i as u32)));
+        }
     }
 
     buffer.write_buffer(&render_device, &render_queue);

--- a/src/sdf/boolean.rs
+++ b/src/sdf/boolean.rs
@@ -1,7 +1,4 @@
 use bevy::prelude::*;
-use bevy::render::extract_component::{
-    ExtractComponent, ExtractComponentPlugin,
-};
 
 pub struct SdfBooleanPlugin;
 
@@ -11,9 +8,6 @@ impl Plugin for SdfBooleanPlugin {
             .register_type::<SdfBooleanOp>()
             .register_type::<SdfOrder>()
             .register_type::<SdfGroup>()
-            .add_plugins(
-                ExtractComponentPlugin::<SdfOperandOf>::default(),
-            )
             .add_observer(assign_sdf_group_children);
     }
 }
@@ -31,26 +25,6 @@ pub enum BooleanOp {
 #[derive(Component)]
 #[relationship(relationship_target = SdfOperands)]
 pub struct SdfOperandOf(pub Entity);
-
-impl ExtractComponent for SdfOperandOf {
-    type QueryData = (
-        &'static SdfOperandOf,
-        &'static SdfBooleanOp,
-        &'static SdfOrder,
-    );
-    type QueryFilter = ();
-    type Out = SdfExtractedOperand;
-
-    fn extract_component(
-        (operand_of, bool_op, order): <Self::QueryData as bevy::ecs::query::QueryData>::Item<'_, '_>,
-    ) -> Option<Self::Out> {
-        Some(SdfExtractedOperand {
-            group_entity: operand_of.0,
-            op: bool_op.0,
-            order: order.0,
-        })
-    }
-}
 
 /// The group entity owns references to all its operand children.
 #[derive(Component, Default)]

--- a/src/sdf/boolean.rs
+++ b/src/sdf/boolean.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 
+use crate::sdf::transform::SdfTransform;
+
 pub struct SdfBooleanPlugin;
 
 impl Plugin for SdfBooleanPlugin {
@@ -100,6 +102,30 @@ impl SdfGroup {
 
     pub fn exclude(self, entity: Entity) -> Self {
         self.push_operand(entity, BooleanOp::Exclusion)
+    }
+
+    /// Position the entire group result in world space.
+    pub fn translate(self, translation: Vec3) -> SdfGroupBuilder {
+        SdfGroupBuilder {
+            group: self,
+            transform: SdfTransform::default()
+                .with_translation(translation),
+        }
+    }
+
+    pub fn build(self) -> impl Bundle {
+        (self, SdfTransform::default())
+    }
+}
+
+pub struct SdfGroupBuilder {
+    group: SdfGroup,
+    transform: SdfTransform,
+}
+
+impl SdfGroupBuilder {
+    pub fn build(self) -> impl Bundle {
+        (self.group, self.transform)
     }
 }
 

--- a/src/sdf/boolean.rs
+++ b/src/sdf/boolean.rs
@@ -1,3 +1,4 @@
+use crate::sdf::transform::SdfTransform;
 use bevy::prelude::*;
 use bevy::render::extract_component::{
     ExtractComponent, ExtractComponentPlugin,
@@ -7,10 +8,11 @@ pub struct SdfBooleanPlugin;
 
 impl Plugin for SdfBooleanPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<SdfGroup>()
-            .add_observer(assign_sdf_group_children)
+        app.register_type::<BooleanOp>()
+            .register_type::<SdfBooleanOp>()
+            .register_type::<SdfOrder>()
             .add_plugins(
-                ExtractComponentPlugin::<SdfOperand>::default(),
+                ExtractComponentPlugin::<SdfOperandOf>::default(),
             );
     }
 }
@@ -24,77 +26,233 @@ pub enum BooleanOp {
     Exclusion = 3,
 }
 
-#[derive(Component, Reflect, Debug, Clone)]
-pub struct SdfGroup {
-    pub(super) operands: Vec<(Entity, BooleanOp)>,
+#[derive(Component)]
+#[relationship(relationship_target = SdfOperands)]
+pub struct SdfOperandOf(pub Entity);
+
+impl ExtractComponent for SdfOperandOf {
+    type QueryData = (
+        &'static SdfOperandOf,
+        &'static SdfBooleanOp,
+        &'static SdfOrder,
+    );
+    type QueryFilter = ();
+    type Out = SdfExtractedOperand;
+
+    fn extract_component(
+        (operand_of, bool_op, order): <Self::QueryData as bevy::ecs::query::QueryData>::Item<'_, '_>,
+    ) -> Option<Self::Out> {
+        Some(SdfExtractedOperand {
+            group_entity: operand_of.0,
+            op: bool_op.0,
+            order: order.0,
+        })
+    }
 }
 
-#[derive(Component, Clone, ExtractComponent)]
-pub struct SdfOperand {
-    pub group_id: u32,
+#[derive(Component, Default)]
+#[relationship_target(relationship = SdfOperandOf, linked_spawn)]
+pub struct SdfOperands(Vec<Entity>);
+
+impl SdfOperands {
+    pub fn iter(&self) -> impl Iterator<Item = Entity> + '_ {
+        self.0.iter().copied()
+    }
+}
+
+/// The boolean operation this operand applies.
+#[derive(Component, Reflect, Debug, Clone, Copy)]
+pub struct SdfBooleanOp(pub BooleanOp);
+
+/// Explicit draw order within a group.
+#[derive(
+    Component,
+    Reflect,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+)]
+pub struct SdfOrder(pub usize);
+
+/// Only exists in the render world.
+/// Produced by SdfOperandOf's ExtractComponent impl.
+#[derive(Component, Clone)]
+pub struct SdfExtractedOperand {
+    pub group_entity: Entity,
     pub op: BooleanOp,
     pub order: usize,
 }
 
-impl SdfGroup {
-    pub fn new(entity: Entity) -> Self {
-        Self {
-            operands: vec![(entity, BooleanOp::Union)],
-        }
-    }
-
-    pub fn push_operand(
-        mut self,
+/// Object-safe trait for inserting a type-erased primitive bundle into the world.
+pub trait PrimitiveBundle: Send + Sync + 'static {
+    fn insert_into(
+        self: Box<Self>,
+        world: &mut World,
         entity: Entity,
-        op: BooleanOp,
-    ) -> Self {
-        self.operands.push((entity, op));
-        self
-    }
+    );
+}
 
-    pub fn union(self, entity: Entity) -> Self {
-        self.push_operand(entity, BooleanOp::Union)
-    }
-
-    pub fn difference(self, entity: Entity) -> Self {
-        self.push_operand(entity, BooleanOp::Difference)
-    }
-
-    pub fn intersect(self, entity: Entity) -> Self {
-        self.push_operand(entity, BooleanOp::Intersection)
-    }
-
-    pub fn exclude(self, entity: Entity) -> Self {
-        self.push_operand(entity, BooleanOp::Exclusion)
+impl<T: Bundle> PrimitiveBundle for T {
+    fn insert_into(
+        self: Box<Self>,
+        world: &mut World,
+        entity: Entity,
+    ) {
+        world.entity_mut(entity).insert(*self);
     }
 }
 
-/// Assigns child relationships and group data for the operands in a boolean group.
-fn assign_sdf_group_children(
-    trigger: On<Add, SdfGroup>,
-    mut commands: Commands,
-    q_groups: Query<&SdfGroup>,
-) {
-    let group_entity = trigger.entity;
-    let Ok(group) = q_groups.get(group_entity) else {
-        return;
-    };
+pub enum SdfOperandDesc {
+    Entity(Entity),
+    Inline {
+        bundle: Box<dyn PrimitiveBundle>,
+        transform: SdfTransform,
+    },
+    NestedGroup {
+        builder: SdfGroup,
+        transform: SdfTransform,
+    },
+}
 
-    let group_id = group_entity.index_u32() + 1;
+pub struct SdfGroup {
+    operands: Vec<(BooleanOp, SdfOperandDesc)>,
+}
 
-    let mut child_entities = Vec::with_capacity(group.operands.len());
-
-    for (i, &(operand_entity, op)) in
-        group.operands.iter().enumerate()
-    {
-        commands.entity(operand_entity).insert(SdfOperand {
-            group_id,
-            op,
-            order: i,
-        });
-
-        child_entities.push(operand_entity);
+impl SdfGroup {
+    pub fn new() -> Self {
+        Self {
+            operands: Vec::new(),
+        }
     }
 
-    commands.entity(group_entity).add_children(&child_entities);
+    pub fn add(mut self, node: (BooleanOp, SdfOperandDesc)) -> Self {
+        self.operands.push(node);
+        self
+    }
+}
+
+/// Anything that can become a group operand by specifying a boolean operation.
+pub trait IntoSdfNode: Sized {
+    fn into_desc(self) -> SdfOperandDesc;
+
+    fn into_node(self, op: BooleanOp) -> (BooleanOp, SdfOperandDesc) {
+        (op, self.into_desc())
+    }
+    fn union(self) -> (BooleanOp, SdfOperandDesc) {
+        self.into_node(BooleanOp::Union)
+    }
+    fn difference(self) -> (BooleanOp, SdfOperandDesc) {
+        self.into_node(BooleanOp::Difference)
+    }
+    fn intersect(self) -> (BooleanOp, SdfOperandDesc) {
+        self.into_node(BooleanOp::Intersection)
+    }
+    fn exclude(self) -> (BooleanOp, SdfOperandDesc) {
+        self.into_node(BooleanOp::Exclusion)
+    }
+}
+
+impl<T: PrimitiveBundle> IntoSdfNode for (T, SdfTransform) {
+    fn into_desc(self) -> SdfOperandDesc {
+        SdfOperandDesc::Inline {
+            bundle: Box::new(self.0),
+            transform: self.1,
+        }
+    }
+}
+
+impl IntoSdfNode for Entity {
+    fn into_desc(self) -> SdfOperandDesc {
+        SdfOperandDesc::Entity(self)
+    }
+}
+
+impl IntoSdfNode for (SdfGroup, SdfTransform) {
+    fn into_desc(self) -> SdfOperandDesc {
+        SdfOperandDesc::NestedGroup {
+            builder: self.0,
+            transform: self.1,
+        }
+    }
+}
+
+impl EntityCommand for SdfGroup {
+    fn apply(self, mut entity: EntityWorldMut) {
+        entity.insert(SdfOperands::default());
+        let group_entity = entity.id();
+
+        entity.world_scope(|world| {
+            for (i, (op, desc)) in
+                self.operands.into_iter().enumerate()
+            {
+                let operand_entity = match desc {
+                    SdfOperandDesc::Entity(e) => e,
+
+                    SdfOperandDesc::Inline { bundle, transform } => {
+                        let e = world.spawn(transform).id();
+                        bundle.insert_into(world, e);
+                        e
+                    }
+
+                    SdfOperandDesc::NestedGroup {
+                        builder,
+                        transform,
+                    } => {
+                        let e = world.spawn(transform).id();
+                        builder.apply(world.entity_mut(e));
+                        e
+                    }
+                };
+
+                world.entity_mut(operand_entity).insert((
+                    SdfOperandOf(group_entity),
+                    SdfBooleanOp(op),
+                    SdfOrder(i),
+                ));
+            }
+        });
+    }
+}
+
+pub trait SdfEntityCommandsExt {
+    fn add_to_group(
+        &mut self,
+        group: Entity,
+        op: BooleanOp,
+        order: usize,
+    ) -> &mut Self;
+
+    fn remove_from_group(&mut self) -> &mut Self;
+
+    fn set_boolean_op(&mut self, op: BooleanOp) -> &mut Self;
+}
+
+impl SdfEntityCommandsExt for EntityCommands<'_> {
+    fn add_to_group(
+        &mut self,
+        group: Entity,
+        op: BooleanOp,
+        order: usize,
+    ) -> &mut Self {
+        self.insert((
+            SdfOperandOf(group),
+            SdfBooleanOp(op),
+            SdfOrder(order),
+        ));
+        self
+    }
+
+    fn remove_from_group(&mut self) -> &mut Self {
+        self.remove::<(SdfOperandOf, SdfBooleanOp, SdfOrder)>();
+        self
+    }
+
+    fn set_boolean_op(&mut self, op: BooleanOp) -> &mut Self {
+        self.insert(SdfBooleanOp(op));
+        self
+    }
 }

--- a/src/sdf/boolean.rs
+++ b/src/sdf/boolean.rs
@@ -129,8 +129,8 @@ impl SdfGroup {
 }
 
 /// Fires when [`SdfGroup`] is added to an entity.
-/// Inserts relationship components on each operand and registers them
-/// as children of the group entity.
+/// Inserts [`SdfOperandOf`], [`SdfBooleanOp`], and [`SdfOrder`] on each
+/// operand so the `SdfOperandOf`/`SdfOperands` relationship is established.
 fn assign_sdf_group_children(
     trigger: On<Add, SdfGroup>,
     mut commands: Commands,
@@ -141,8 +141,6 @@ fn assign_sdf_group_children(
         return;
     };
 
-    let mut child_entities = Vec::with_capacity(group.operands.len());
-
     for (i, &(operand_entity, op)) in
         group.operands.iter().enumerate()
     {
@@ -151,10 +149,7 @@ fn assign_sdf_group_children(
             SdfBooleanOp(op),
             SdfOrder(i),
         ));
-        child_entities.push(operand_entity);
     }
-
-    commands.entity(group_entity).add_children(&child_entities);
 }
 
 pub trait SdfEntityCommandsExt {

--- a/src/sdf/boolean.rs
+++ b/src/sdf/boolean.rs
@@ -1,4 +1,3 @@
-use crate::sdf::transform::SdfTransform;
 use bevy::prelude::*;
 use bevy::render::extract_component::{
     ExtractComponent, ExtractComponentPlugin,
@@ -11,9 +10,11 @@ impl Plugin for SdfBooleanPlugin {
         app.register_type::<BooleanOp>()
             .register_type::<SdfBooleanOp>()
             .register_type::<SdfOrder>()
+            .register_type::<SdfGroup>()
             .add_plugins(
                 ExtractComponentPlugin::<SdfOperandOf>::default(),
-            );
+            )
+            .add_observer(assign_sdf_group_children);
     }
 }
 
@@ -26,6 +27,7 @@ pub enum BooleanOp {
     Exclusion = 3,
 }
 
+/// This entity is a member of an SDF group (the group entity carries [`SdfOperands`]).
 #[derive(Component)]
 #[relationship(relationship_target = SdfOperands)]
 pub struct SdfOperandOf(pub Entity);
@@ -50,6 +52,7 @@ impl ExtractComponent for SdfOperandOf {
     }
 }
 
+/// The group entity owns references to all its operand children.
 #[derive(Component, Default)]
 #[relationship_target(relationship = SdfOperandOf, linked_spawn)]
 pub struct SdfOperands(Vec<Entity>);
@@ -78,8 +81,7 @@ pub struct SdfBooleanOp(pub BooleanOp);
 )]
 pub struct SdfOrder(pub usize);
 
-/// Only exists in the render world.
-/// Produced by SdfOperandOf's ExtractComponent impl.
+/// Render-world copy produced by [`SdfOperandOf`]'s [`ExtractComponent`] impl.
 #[derive(Component, Clone)]
 pub struct SdfExtractedOperand {
     pub group_entity: Entity,
@@ -87,138 +89,76 @@ pub struct SdfExtractedOperand {
     pub order: usize,
 }
 
-/// Object-safe trait for inserting a type-erased primitive bundle into the world.
-pub trait PrimitiveBundle: Send + Sync + 'static {
-    fn insert_into(
-        self: Box<Self>,
-        world: &mut World,
-        entity: Entity,
-    );
-}
-
-impl<T: Bundle> PrimitiveBundle for T {
-    fn insert_into(
-        self: Box<Self>,
-        world: &mut World,
-        entity: Entity,
-    ) {
-        world.entity_mut(entity).insert(*self);
-    }
-}
-
-pub enum SdfOperandDesc {
-    Entity(Entity),
-    Inline {
-        bundle: Box<dyn PrimitiveBundle>,
-        transform: SdfTransform,
-    },
-    NestedGroup {
-        builder: SdfGroup,
-        transform: SdfTransform,
-    },
-}
-
+#[derive(Component, Reflect, Debug, Clone)]
 pub struct SdfGroup {
-    operands: Vec<(BooleanOp, SdfOperandDesc)>,
+    pub(crate) operands: Vec<(Entity, BooleanOp)>,
 }
 
 impl SdfGroup {
-    pub fn new() -> Self {
+    /// Start a new group with `entity` as the first operand (unioned).
+    pub fn new(entity: Entity) -> Self {
         Self {
-            operands: Vec::new(),
+            operands: vec![(entity, BooleanOp::Union)],
         }
     }
 
-    pub fn add(mut self, node: (BooleanOp, SdfOperandDesc)) -> Self {
-        self.operands.push(node);
+    pub fn push_operand(
+        mut self,
+        entity: Entity,
+        op: BooleanOp,
+    ) -> Self {
+        self.operands.push((entity, op));
         self
     }
-}
 
-/// Anything that can become a group operand by specifying a boolean operation.
-pub trait IntoSdfNode: Sized {
-    fn into_desc(self) -> SdfOperandDesc;
+    pub fn union(self, entity: Entity) -> Self {
+        self.push_operand(entity, BooleanOp::Union)
+    }
 
-    fn into_node(self, op: BooleanOp) -> (BooleanOp, SdfOperandDesc) {
-        (op, self.into_desc())
+    pub fn difference(self, entity: Entity) -> Self {
+        self.push_operand(entity, BooleanOp::Difference)
     }
-    fn union(self) -> (BooleanOp, SdfOperandDesc) {
-        self.into_node(BooleanOp::Union)
+
+    pub fn intersect(self, entity: Entity) -> Self {
+        self.push_operand(entity, BooleanOp::Intersection)
     }
-    fn difference(self) -> (BooleanOp, SdfOperandDesc) {
-        self.into_node(BooleanOp::Difference)
-    }
-    fn intersect(self) -> (BooleanOp, SdfOperandDesc) {
-        self.into_node(BooleanOp::Intersection)
-    }
-    fn exclude(self) -> (BooleanOp, SdfOperandDesc) {
-        self.into_node(BooleanOp::Exclusion)
+
+    pub fn exclude(self, entity: Entity) -> Self {
+        self.push_operand(entity, BooleanOp::Exclusion)
     }
 }
 
-impl<T: PrimitiveBundle> IntoSdfNode for (T, SdfTransform) {
-    fn into_desc(self) -> SdfOperandDesc {
-        SdfOperandDesc::Inline {
-            bundle: Box::new(self.0),
-            transform: self.1,
-        }
+/// Fires when [`SdfGroup`] is added to an entity.
+/// Inserts relationship components on each operand and registers them
+/// as children of the group entity.
+fn assign_sdf_group_children(
+    trigger: On<Add, SdfGroup>,
+    mut commands: Commands,
+    q_groups: Query<&SdfGroup>,
+) {
+    let group_entity = trigger.entity;
+    let Ok(group) = q_groups.get(group_entity) else {
+        return;
+    };
+
+    let mut child_entities = Vec::with_capacity(group.operands.len());
+
+    for (i, &(operand_entity, op)) in
+        group.operands.iter().enumerate()
+    {
+        commands.entity(operand_entity).insert((
+            SdfOperandOf(group_entity),
+            SdfBooleanOp(op),
+            SdfOrder(i),
+        ));
+        child_entities.push(operand_entity);
     }
-}
 
-impl IntoSdfNode for Entity {
-    fn into_desc(self) -> SdfOperandDesc {
-        SdfOperandDesc::Entity(self)
-    }
-}
-
-impl IntoSdfNode for (SdfGroup, SdfTransform) {
-    fn into_desc(self) -> SdfOperandDesc {
-        SdfOperandDesc::NestedGroup {
-            builder: self.0,
-            transform: self.1,
-        }
-    }
-}
-
-impl EntityCommand for SdfGroup {
-    fn apply(self, mut entity: EntityWorldMut) {
-        entity.insert(SdfOperands::default());
-        let group_entity = entity.id();
-
-        entity.world_scope(|world| {
-            for (i, (op, desc)) in
-                self.operands.into_iter().enumerate()
-            {
-                let operand_entity = match desc {
-                    SdfOperandDesc::Entity(e) => e,
-
-                    SdfOperandDesc::Inline { bundle, transform } => {
-                        let e = world.spawn(transform).id();
-                        bundle.insert_into(world, e);
-                        e
-                    }
-
-                    SdfOperandDesc::NestedGroup {
-                        builder,
-                        transform,
-                    } => {
-                        let e = world.spawn(transform).id();
-                        builder.apply(world.entity_mut(e));
-                        e
-                    }
-                };
-
-                world.entity_mut(operand_entity).insert((
-                    SdfOperandOf(group_entity),
-                    SdfBooleanOp(op),
-                    SdfOrder(i),
-                ));
-            }
-        });
-    }
+    commands.entity(group_entity).add_children(&child_entities);
 }
 
 pub trait SdfEntityCommandsExt {
+    /// Add this entity to a group as an operand.
     fn add_to_group(
         &mut self,
         group: Entity,
@@ -226,9 +166,14 @@ pub trait SdfEntityCommandsExt {
         order: usize,
     ) -> &mut Self;
 
+    /// Remove this entity from its current group.
     fn remove_from_group(&mut self) -> &mut Self;
 
+    /// Change the boolean operation without moving the entity.
     fn set_boolean_op(&mut self, op: BooleanOp) -> &mut Self;
+
+    /// Change the evaluation order within the group.
+    fn set_order(&mut self, order: usize) -> &mut Self;
 }
 
 impl SdfEntityCommandsExt for EntityCommands<'_> {
@@ -253,6 +198,11 @@ impl SdfEntityCommandsExt for EntityCommands<'_> {
 
     fn set_boolean_op(&mut self, op: BooleanOp) -> &mut Self {
         self.insert(SdfBooleanOp(op));
+        self
+    }
+
+    fn set_order(&mut self, order: usize) -> &mut Self {
+        self.insert(SdfOrder(order));
         self
     }
 }

--- a/src/sdf/boolean.rs
+++ b/src/sdf/boolean.rs
@@ -27,7 +27,7 @@ pub enum BooleanOp {
     Exclusion = 3,
 }
 
-/// This entity is a member of an SDF group (the group entity carries [`SdfOperands`]).
+/// This entity is a member of an SDF group which the group entity carries [`SdfOperands`]).
 #[derive(Component)]
 #[relationship(relationship_target = SdfOperands)]
 pub struct SdfOperandOf(pub Entity);

--- a/src/sdf/boolean.rs
+++ b/src/sdf/boolean.rs
@@ -55,7 +55,8 @@ pub struct SdfBooleanOp(pub BooleanOp);
 )]
 pub struct SdfOrder(pub usize);
 
-/// Render-world copy produced by [`SdfOperandOf`]'s [`ExtractComponent`] impl.
+/// Render-world copy of [`SdfOperandOf`], [`SdfBooleanOp`], and [`SdfOrder`],
+/// produced during extraction by `extract_sdf_operands` in `sdf.rs`.
 #[derive(Component, Clone)]
 pub struct SdfExtractedOperand {
     pub group_entity: Entity,

--- a/src/sdf/primitves.rs
+++ b/src/sdf/primitves.rs
@@ -4,6 +4,8 @@ use bevy::render::extract_component::{
 };
 use bevy::render::render_resource::ShaderType;
 
+use crate::sdf::transform::SdfTransform;
+
 pub struct SdfPrimitivePlugin;
 
 impl Plugin for SdfPrimitivePlugin {
@@ -28,6 +30,7 @@ impl Plugin for SdfPrimitivePlugin {
     Clone,
     Copy,
 )]
+#[require(SdfTransform)]
 pub struct SdfSphere {
     pub radius: f32,
 }
@@ -51,6 +54,7 @@ impl Default for SdfSphere {
     Clone,
     Copy,
 )]
+#[require(SdfTransform)]
 pub struct SdfCuboid {
     pub extents: Vec3,
 }
@@ -74,6 +78,7 @@ impl Default for SdfCuboid {
     Clone,
     Copy,
 )]
+#[require(SdfTransform)]
 pub struct SdfRoundCuboid {
     pub extents: Vec3,
     pub radius: f32,
@@ -101,7 +106,7 @@ impl Default for SdfRoundCuboid {
     Clone,
     Copy,
 )]
-
+#[require(SdfTransform)]
 pub struct SdfCapsule {
     pub point_a: Vec3,
     pub point_b: Vec3,
@@ -131,7 +136,7 @@ impl Default for SdfCapsule {
     Clone,
     Copy,
 )]
-
+#[require(SdfTransform)]
 pub struct SdfTorus {
     pub ring_radius: f32,
     pub tube_radius: f32,

--- a/src/sdf/transform.rs
+++ b/src/sdf/transform.rs
@@ -1,3 +1,4 @@
+use crate::sdf::boolean::{SdfOperandOf, SdfOperands};
 use bevy::math::Affine3A;
 use bevy::prelude::*;
 use bevy::render::extract_component::{
@@ -40,28 +41,30 @@ fn propagate_transform(
     // TODO: Use the Ref to skip unchanged transforms.
     mut q_root_transforms: Query<
         (&mut SdfGlobalTransform, Ref<SdfTransform>, Entity),
-        Without<ChildOf>,
+        Without<SdfOperandOf>,
     >,
     mut q_child_transforms: Query<
         (&mut SdfGlobalTransform, Ref<SdfTransform>),
-        With<ChildOf>,
+        With<SdfOperandOf>,
     >,
-    q_children: Query<&Children>,
+    q_operands: Query<&SdfOperands>,
 ) {
     for (mut global_transform, transform, entity) in
         q_root_transforms.iter_mut()
     {
         *global_transform = SdfGlobalTransform::from(*transform);
 
-        if let Ok(children) = q_children.get(entity) {
+        if let Ok(operands) = q_operands.get(entity) {
             // Iteratively propagate the transform.
             // TODO: Optimize this:
             // - Offer stack based recursive?
             // - Parallelize this algo!
             // - Static analysis, skip subtrees that are not mutated.
             let mut global_transforms = vec![*global_transform];
-            let mut children =
-                children.iter().map(|e| (e, 0)).collect::<Vec<_>>();
+            let mut children = operands
+                .iter()
+                .map(|e| (e, 0usize))
+                .collect::<Vec<_>>();
 
             while let Some((child, idx)) = children.pop()
                 && let Ok((
@@ -75,9 +78,9 @@ fn propagate_transform(
 
                 let new_idx = global_transforms.len();
                 global_transforms.push(*child_global_transform);
-                if let Ok(nested_children) = q_children.get(child) {
+                if let Ok(nested_operands) = q_operands.get(child) {
                     children.extend(
-                        nested_children.iter().map(|e| (e, new_idx)),
+                        nested_operands.iter().map(|e| (e, new_idx)),
                     );
                 }
             }

--- a/src/sdf/transform.rs
+++ b/src/sdf/transform.rs
@@ -52,7 +52,11 @@ fn propagate_transform(
     for (mut global_transform, transform, entity) in
         q_root_transforms.iter_mut()
     {
-        *global_transform = SdfGlobalTransform::from(*transform);
+        // Only recompute the root global transform if its local changed.
+        let root_changed = transform.is_changed();
+        if root_changed {
+            *global_transform = SdfGlobalTransform::from(*transform);
+        }
 
         if let Ok(operands) = q_operands.get(entity) {
             // Iteratively propagate the transform.
@@ -63,24 +67,37 @@ fn propagate_transform(
             let mut global_transforms = vec![*global_transform];
             let mut children = operands
                 .iter()
-                .map(|e| (e, 0usize))
+                .map(|e| (e, 0usize, root_changed))
                 .collect::<Vec<_>>();
 
-            while let Some((child, idx)) = children.pop()
-                && let Ok((
-                    mut child_global_transform,
-                    child_transform,
-                )) = q_child_transforms.get_mut(child)
-            {
-                let global_transform = &global_transforms[idx];
-                *child_global_transform =
-                    global_transform.mul_transform(*child_transform);
+            let mut head = 0;
+            while head < children.len() {
+                let (child, idx, parent_changed) = children[head];
+                head += 1;
+
+                let Ok((mut child_global_transform, child_transform)) =
+                    q_child_transforms.get_mut(child)
+                else {
+                    continue;
+                };
+
+                let child_changed =
+                    parent_changed || child_transform.is_changed();
+
+                if child_changed {
+                    let global_transform = &global_transforms[idx];
+                    *child_global_transform = global_transform
+                        .mul_transform(*child_transform);
+                }
 
                 let new_idx = global_transforms.len();
                 global_transforms.push(*child_global_transform);
+
                 if let Ok(nested_operands) = q_operands.get(child) {
                     children.extend(
-                        nested_operands.iter().map(|e| (e, new_idx)),
+                        nested_operands
+                            .iter()
+                            .map(|e| (e, new_idx, child_changed)),
                     );
                 }
             }
@@ -126,10 +143,12 @@ impl Default for SdfTransform {
 impl From<SdfTransform> for SdfGlobalTransform {
     fn from(value: SdfTransform) -> Self {
         Self {
-            world_from_local: Affine3A::from_rotation_translation(
-                value.rotation,
-                value.translation,
-            ),
+            world_from_local:
+                Affine3A::from_scale_rotation_translation(
+                    Vec3::splat(value.scale),
+                    value.rotation,
+                    value.translation,
+                ),
             scale: value.scale,
         }
     }

--- a/src/sdf/transform.rs
+++ b/src/sdf/transform.rs
@@ -128,6 +128,10 @@ impl SdfTransform {
         self.scale = scale;
         self
     }
+
+    pub fn from_xyz(x: f32, y: f32, z: f32) -> Self {
+        Self::default().with_translation(Vec3::new(x, y, z))
+    }
 }
 
 impl Default for SdfTransform {


### PR DESCRIPTION
Resolved #17 

Replaces the rigid `ChildOf` operand approach with a custom `SdfOperandOf`/`SdfOperands` relationship system, enabling fully nested SDF group hierarchies.
### Changes

#### 1. Relationship Model (`src/sdf/boolean.rs`)
* **`SdfOperandOf(Entity)`**: Component on each operand entity pointing to its parent group.
* **`SdfOperands(Vec<Entity>)`**: Component on the group entity listing its children (uses Bevy's `#[relationship_target]` with `linked_spawn` for automatic cleanup).
* **`SdfBooleanOp(BooleanOp)` / `SdfOrder(usize)`**: Per-operand metadata for evaluation order and boolean operation.
* **`SdfExtractedOperand`**: Render-world copy of operand state for GPU buffer construction.
* **`SdfEntityCommandsExt` trait**: Ergonomic `add_to_group()`, `remove_from_group()`, `set_boolean_op()`, and `set_order()` methods.

#### 2. Flat Preorder Buffer Layout (`src/sdf.rs`)
* Replaces non-deterministic `group_id` assignment.
* **`emit_group()`**: Recursively writes a group header + its children (primitives and sub-groups) into a flat `BufferVec<SdfInput>` in DFS preorder.
* **Parent Index Pointer**: Each child's `parent_index` is set to the header's buffer position, giving the GPU a stable tree to walk.
* **`update_input_buffers`**: Handles root-level primitives (no parent), group hierarchy collection, and order sorting.
* **Component Tracking**: Proper `RemovedComponents` tracking implemented for both primitives and operands.

#### 3. Stack-Based Shader Composition (`assets/shaders/sdf_raymarch.wgsl`)
* Walks the flat preorder buffer with an explicit stack (max depth 8).
* Group headers push the current accumulator and open a new scope; leaf primitives evaluate and fold into the current scope.
* **Drain Loop**: Pops closed groups by comparing `parent_index` against stack entries.
* **Fallback Strategy**: Falls back to `min()` on stack overflow instead of silently dropping geometry.
* Correctly handles sibling groups, nested groups, and mixed primitive/subgroup ordering.

#### 4. Transform Propagation (`src/sdf/transform.rs`)
* **`SdfTransform`**: Local, user-authored transform with `#[require(SdfGlobalTransform)]`.
* **`propagate_transform` system**: Walks the operand graph iteratively, recomputing `world_from_local` (including scale via `Affine3A`) only when local transforms change.
* Skips entities with `SdfOperandOf` and starts from root groups (`Without<SdfOperandOf>`).

#### 5. Builder API & Ergonomics
* **Chained Syntax**: `SdfGroup::new(entity).union(b).difference(c).intersect(d)` allows fluent operand construction.
* **One-Shot Spawning**: `.translate(Vec3) -> SdfGroupBuilder`, `.build() -> impl Bundle`.
* **Shorthands**: `SdfTransform::from_xyz(x, y, z)` shorthand added.
* **Auto-Insertion**: All primitive types (`SdfSphere`, etc.) and `SdfGroup` have `#[require(SdfTransform)]`.

#### 6. Performance Optimizations
* **Early Returns**: `update_primitive_buffers` and `update_input_buffers` early-return when nothing changed.
* **Filtered Extraction**: `extract_sdf_operands` uses `Changed<T>` filters to avoid redundant extraction.
* **Skipped Render Pass**: SDF render pass is skipped entirely when `input_count == 0`.
* **GPU Data Sanity**: GPU writes always include at least a sentinel element to prevent stale data.