### PR TITLE
Bezier shader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,15 @@ edition = "2024"
 [dependencies]
 bevy = { version = "0.18.0", default-features = false, features = ["3d", "file_watcher"] }
 bevy_egui = "0.39.0"
+
+[[example]]
+name = "bezier_single"
+path = "examples/bezier_single.rs"
+
+[[example]]
+name = "bezier_multi"
+path = "examples/bezier_multi.rs"
+
+[[example]]
+name = "bezier_realtime"
+path = "examples/bezier_realtime.rs"

--- a/assets/shaders/bezier.wgsl
+++ b/assets/shaders/bezier.wgsl
@@ -182,6 +182,7 @@ fn draw_debug_overlay(color: vec3f, uv: vec2f, curve: BezierCurve) -> vec3f {
 fn fragment(in: VertexOutput) -> @location(0) vec4f {
     let uv   = in.uv;
     var color = data.background_color.rgb;
+    var alpha = data.background_color.a;
 
     for (var i = 0u; i < data.curve_count; i++) {
         let curve = data.curves[i];
@@ -193,13 +194,15 @@ fn fragment(in: VertexOutput) -> @location(0) vec4f {
         }
         let aa   = fwidth(d);
         let mask = 1.0 - smoothstep(curve.width - aa, curve.width + aa, d);
-        color    = mix(color, curve.color.rgb, mask * curve.color.a);
+        let coverage = mask * curve.color.a;
+        color    = mix(color, curve.color.rgb, coverage);
+        alpha    = mix(alpha, 1.0, coverage);
 
         if (curve.debug != 0u) {
             color = draw_debug_overlay(color, uv, curve);
         }
     }
 
-    return vec4f(color, 1.0);
+    return vec4f(color, alpha);
 }
 

--- a/assets/shaders/bezier.wgsl
+++ b/assets/shaders/bezier.wgsl
@@ -1,0 +1,205 @@
+#import bevy_pbr::forward_io::VertexOutput
+
+struct BezierCurve {
+    // quadratic uses p0..p2
+    // cubic uses p0..p3
+    p0:    vec2f,
+    p1:    vec2f,
+    p2:    vec2f,
+    p3:    vec2f,
+    color: vec4f,
+    width: f32,
+    // 0 = quadratic
+    // 1 = cubic
+    kind:  u32,
+    // non-zero = draw control points
+    debug: u32,
+}
+
+struct BezierBuffer {
+    background_color:   vec4f,
+    curve_count:        u32,
+    _padding:           array<f32, 3>,
+    curves:             array<BezierCurve, 32>,
+}
+
+@group(3) @binding(0) var<storage, read> data: BezierBuffer;
+
+
+// https://www.shadertoy.com/view/MlKcDD
+const SQRT3: f32 = 1.732050807568877;
+
+fn cross2(a: vec2f, b: vec2f) -> f32 {
+    return a.x * b.y - a.y * b.x;
+}
+
+// Signed distance to a line segment
+// Either positive or negative, depending on which side the point falls
+fn sdf_line_partition(p: vec2f, a: vec2f, b: vec2f) -> f32 {
+    let ba = b - a;
+    let pa = p - a;
+    let h = saturate(dot(pa, ba) / dot(ba, ba));
+    let k = pa - h * ba;
+    let n = vec2f(ba.y, -ba.x);
+    if (dot(k, n) >= 0.0) {
+        return length(k);
+    }
+    return -length(k);
+}
+
+fn sdf_bezier_quadratic(pos: vec2f, A: vec2f, B: vec2f, C: vec2f) -> f32 {
+    let EPSILON = 1e-3;
+    let ONE_THIRD = 1.0 / 3.0;
+
+    let ab_equal = all(A == B);
+    let bc_equal = all(B == C);
+    let ac_equal = all(A == C);
+
+    if (ab_equal && bc_equal) {
+        return distance(pos, A);
+    } else if (ab_equal || ac_equal) {
+        return sdf_line_partition(pos, B, C);
+    } else if (bc_equal) {
+        return sdf_line_partition(pos, A, C);
+    }
+
+    if (abs(dot(normalize(B - A), normalize(C - B)) - 1.0) < EPSILON) {
+        return sdf_line_partition(pos, A, C);
+    }
+
+    let a = B - A;
+    let b = A - 2.0 * B + C;
+    let c = a * 2.0;
+    let d = A - pos;
+
+    let kk = 1.0 / dot(b, b);
+    let kx = kk * dot(a, b);
+    let ky = kk * (2.0 * dot(a, a) + dot(d, b)) * ONE_THIRD;
+    let kz = kk * dot(d, a);
+
+    var res = 0.0;
+    var sgn = 0.0;
+
+    let p = ky - kx * kx;
+    let p3 = p * p * p;
+    let q = kx * (2.0 * kx * kx - 3.0 * ky) + kz;
+    let h = q * q + 4.0 * p3;
+
+    if (h >= 0.0) {
+        // One real root
+        let hs = sqrt(h);
+        let x = 0.5 * (vec2f(hs, -hs) - q);
+        let uv = sign(x) * pow(abs(x), vec2f(ONE_THIRD));
+        let t = saturate(uv.x + uv.y - kx) + EPSILON;
+        let qv = d + (c + b * t) * t;
+        res = dot(qv, qv);
+        sgn = cross2(c + 2.0 * b * t, qv);
+    } else {
+        // Three real roots
+        let z = sqrt(-p);
+        let v = acos(q / (p * z * 2.0)) * ONE_THIRD;
+        let m = cos(v);
+        let n = sin(v) * SQRT3;
+        let t = saturate(vec3f(m + m, -n - m, n - m) * z - kx) + EPSILON;
+        let qx = d + (c + b * t.x) * t.x;
+        let dx = dot(qx, qx);
+        let sx = cross2(c + 2.0 * b * t.x, qx);
+        let qy = d + (c + b * t.y) * t.y;
+        let dy = dot(qy, qy);
+        let sy = cross2(c + 2.0 * b * t.y, qy);
+        if (dx < dy) {
+            res = dx;
+            sgn = sx;
+        } else {
+            res = dy;
+            sgn = sy;
+        }
+    }
+
+    return sign(sgn) * sqrt(res);
+}
+
+// Cubic curves are derived from the quadratic SDFs
+// split the cubic at the midpoint, and fit each half with a tangent-matched
+// quadratic and take the min
+fn sdf_bezier_cubic(pos: vec2f, p0: vec2f, p1: vec2f, p2: vec2f, p3: vec2f) -> f32 {
+    let m  = (p0 + 3.0 * p1 + 3.0 * p2 + p3) * 0.125;
+    let l1 = (p0 + p1) * 0.5;
+    let l2 = (p0 + 2.0 * p1 + p2) * 0.25;
+    let ql = (3.0 * (l1 + l2) - p0 - m) * 0.25;
+    let r1 = (p1 + 2.0 * p2 + p3) * 0.25;
+    let r2 = (p2 + p3) * 0.5;
+    let qr = (3.0 * (r1 + r2) - m - p3) * 0.25;
+
+    let d0 = sdf_bezier_quadratic(pos, p0, ql, m);
+    let d1 = sdf_bezier_quadratic(pos, m, qr, p3);
+    if (abs(d0) < abs(d1)) {
+        return d0;
+    }
+    return d1;
+}
+
+// DEBUG
+// hard-coded values, doesnt matter
+const DEBUG_POINT_RADIUS: f32 = 0.006;
+const DEBUG_LINE_WIDTH: f32 = 0.0012;
+const DEBUG_POINT_COLOR: vec4f = vec4f(1.0, 0.0, 0.0, 0.5);
+const DEBUG_LINE_COLOR: vec4f = vec4f(1.0, 1.0, 1.0, 0.35);
+
+fn draw_debug_point(color: vec3f, uv: vec2f, p: vec2f) -> vec3f {
+    let d    = distance(uv, p);
+    let aa   = fwidth(d);
+    let mask = 1.0 - smoothstep(DEBUG_POINT_RADIUS - aa, DEBUG_POINT_RADIUS + aa, d);
+    return mix(color, DEBUG_POINT_COLOR.rgb, mask * DEBUG_POINT_COLOR.a);
+}
+
+fn draw_debug_line(color: vec3f, uv: vec2f, a: vec2f, b: vec2f) -> vec3f {
+    let d    = abs(sdf_line_partition(uv, a, b));
+    let aa   = fwidth(d);
+    let mask = 1.0 - smoothstep(DEBUG_LINE_WIDTH - aa, DEBUG_LINE_WIDTH + aa, d);
+    return mix(color, DEBUG_LINE_COLOR.rgb, mask * DEBUG_LINE_COLOR.a);
+}
+
+// Draws the control points, and the lines between them
+fn draw_debug_overlay(color: vec3f, uv: vec2f, curve: BezierCurve) -> vec3f {
+    var c = color;
+    c = draw_debug_line(c, uv, curve.p0, curve.p1);
+    c = draw_debug_line(c, uv, curve.p1, curve.p2);
+    if (curve.kind != 0u) {
+        c = draw_debug_line(c, uv, curve.p2, curve.p3);
+    }
+    c = draw_debug_point(c, uv, curve.p0);
+    c = draw_debug_point(c, uv, curve.p1);
+    c = draw_debug_point(c, uv, curve.p2);
+    if (curve.kind != 0u) {
+        c = draw_debug_point(c, uv, curve.p3);
+    }
+    return c;
+}
+// 
+
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4f {
+    let uv   = in.uv;
+    var color = data.background_color.rgb;
+
+    for (var i = 0u; i < data.curve_count; i++) {
+        let curve = data.curves[i];
+        var d: f32;
+        if (curve.kind == 0u) {
+            d = abs(sdf_bezier_quadratic(uv, curve.p0, curve.p1, curve.p2));
+        } else {
+            d = abs(sdf_bezier_cubic(uv, curve.p0, curve.p1, curve.p2, curve.p3));
+        }
+        let aa   = fwidth(d);
+        let mask = 1.0 - smoothstep(curve.width - aa, curve.width + aa, d);
+        color    = mix(color, curve.color.rgb, mask * curve.color.a);
+
+        if (curve.debug != 0u) {
+            color = draw_debug_overlay(color, uv, curve);
+        }
+    }
+
+    return vec4f(color, 1.0);
+}
+

--- a/examples/bezier_multi.rs
+++ b/examples/bezier_multi.rs
@@ -1,0 +1,137 @@
+//! Example: three planes with several cubic Bezier curves each.
+//!
+//! Bezier curves are drawn on planes, that can be oriented in
+//! whatever direction.
+
+use bevy::prelude::*;
+use bevy::render::storage::ShaderStorageBuffer;
+use xad::bezier::{BezierCurve, BezierMaterial, BezierPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, BezierPlugin))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+const HALF_EXTENT: f32 = 1.6;
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<BezierMaterial>>,
+    mut storage_buffers: ResMut<Assets<ShaderStorageBuffer>>,
+) {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 1.0, 4.5))
+            .looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    let mesh_left =
+        meshes.add(Plane3d::new(Vec3::X, Vec2::splat(HALF_EXTENT)));
+    let mesh_bottom =
+        meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(HALF_EXTENT)));
+    let mesh_right = meshes
+        .add(Plane3d::new(Vec3::NEG_X, Vec2::splat(HALF_EXTENT)));
+
+    let mat_left = materials.add(BezierMaterial::from_curves(
+        LinearRgba::new(0.05, 0.04, 0.10, 1.0),
+        vec![
+            BezierCurve::new(
+                Vec2::new(0.10, 0.20),
+                Vec2::new(0.40, 0.90),
+                Vec2::new(0.60, 0.10),
+                Vec2::new(0.90, 0.80),
+            )
+            .with_color(LinearRgba::new(1.00, 0.30, 0.30, 1.0))
+            .with_width(0.001),
+            BezierCurve::new(
+                Vec2::new(0.10, 0.85),
+                Vec2::new(0.35, 0.65),
+                Vec2::new(0.65, 0.35),
+                Vec2::new(0.90, 0.15),
+            )
+            .with_color(LinearRgba::new(1.00, 0.85, 0.10, 1.0))
+            .with_width(0.001),
+        ],
+        &mut storage_buffers,
+    ));
+    commands.spawn((
+        Mesh3d(mesh_left),
+        MeshMaterial3d(mat_left),
+        Transform::from_translation(Vec3::new(
+            -HALF_EXTENT,
+            0.0,
+            0.0,
+        )),
+    ));
+
+    let mat_bottom = materials.add(BezierMaterial::from_curves(
+        LinearRgba::new(0.04, 0.10, 0.06, 1.0),
+        vec![
+            BezierCurve::new(
+                Vec2::new(0.10, 0.50),
+                Vec2::new(0.30, 0.95),
+                Vec2::new(0.70, 0.95),
+                Vec2::new(0.90, 0.50),
+            )
+            .with_color(LinearRgba::new(0.30, 1.00, 0.45, 1.0))
+            .with_width(0.016),
+            BezierCurve::new(
+                Vec2::new(0.05, 0.50),
+                Vec2::new(0.30, 0.10),
+                Vec2::new(0.70, 0.90),
+                Vec2::new(0.95, 0.50),
+            )
+            .with_color(LinearRgba::new(0.20, 0.80, 1.00, 1.0))
+            .with_width(0.011),
+            BezierCurve::new(
+                Vec2::new(0.10, 0.15),
+                Vec2::new(0.40, 0.50),
+                Vec2::new(0.60, 0.50),
+                Vec2::new(0.90, 0.15),
+            )
+            .with_color(LinearRgba::new(0.90, 0.40, 1.00, 1.0))
+            .with_width(0.011),
+        ],
+        &mut storage_buffers,
+    ));
+    commands.spawn((
+        Mesh3d(mesh_bottom),
+        MeshMaterial3d(mat_bottom),
+        Transform::from_translation(Vec3::new(
+            0.0,
+            -HALF_EXTENT,
+            0.0,
+        )),
+    ));
+
+    let mat_right = materials.add(BezierMaterial::from_curves(
+        LinearRgba::new(0.10, 0.06, 0.04, 1.0),
+        vec![
+            BezierCurve::new(
+                Vec2::new(0.10, 0.10),
+                Vec2::new(0.90, 0.10),
+                Vec2::new(0.10, 0.90),
+                Vec2::new(0.90, 0.90),
+            )
+            .with_color(LinearRgba::new(1.00, 0.55, 0.10, 1.0))
+            .with_width(0.016),
+            BezierCurve::new(
+                Vec2::new(0.10, 0.90),
+                Vec2::new(0.90, 0.90),
+                Vec2::new(0.10, 0.10),
+                Vec2::new(0.90, 0.10),
+            )
+            .with_color(LinearRgba::new(1.00, 1.00, 1.00, 0.65))
+            .with_width(0.009),
+        ],
+        &mut storage_buffers,
+    ));
+    commands.spawn((
+        Mesh3d(mesh_right),
+        MeshMaterial3d(mat_right),
+        Transform::from_translation(Vec3::new(HALF_EXTENT, 0.0, 0.0)),
+    ));
+}

--- a/examples/bezier_realtime.rs
+++ b/examples/bezier_realtime.rs
@@ -1,0 +1,204 @@
+//! Example: one plane whose Bezier control points wander randomly.
+//!
+//! Showcases updating a `BezierMaterial`'s GPU buffer every frame to animate
+//! curves in realtime, rather than baking them once at spawn time.
+
+use bevy::prelude::*;
+use bevy::render::storage::ShaderStorageBuffer;
+use xad::bezier::{BezierCurve, BezierMaterial, BezierPlugin};
+
+const CURVE_COLORS: [LinearRgba; 3] = [
+    LinearRgba::new(1.00, 0.45, 0.10, 1.0),
+    LinearRgba::new(0.20, 0.80, 1.00, 1.0),
+    LinearRgba::new(0.90, 0.40, 1.00, 1.0),
+];
+const CURVE_WIDTH: f32 = 0.008;
+const POINT_BOUNDS_MIN: f32 = 0.05;
+const POINT_BOUNDS_MAX: f32 = 0.95;
+const MAX_SPEED: f32 = 0.35;
+const ACCEL: f32 = 0.6;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, BezierPlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, wander_control_points)
+        .run();
+}
+
+// PCG32 PRNG (https://www.pcg-random.org/)
+struct Rng {
+    state: u64,
+    inc: u64,
+}
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        let mut rng = Self {
+            state: 0,
+            inc: (seed << 1) | 1,
+        };
+        rng.next_u32();
+        rng.state = rng.state.wrapping_add(seed);
+        rng.next_u32();
+        rng
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        let old_state = self.state;
+        self.state = old_state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(self.inc);
+        let xorshifted =
+            (((old_state >> 18) ^ old_state) >> 27) as u32;
+        let rot = (old_state >> 59) as u32;
+        xorshifted.rotate_right(rot)
+    }
+
+    fn next_f32(&mut self) -> f32 {
+        (self.next_u32() >> 8) as f32 / (1u32 << 24) as f32
+    }
+
+    fn range(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + self.next_f32() * (hi - lo)
+    }
+}
+
+#[derive(Resource)]
+struct WanderingCurves {
+    material: Handle<BezierMaterial>,
+    background: LinearRgba,
+    points: Vec<[Vec2; 4]>,
+    velocities: Vec<[Vec2; 4]>,
+    rng: Rng,
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<BezierMaterial>>,
+    mut storage_buffers: ResMut<Assets<ShaderStorageBuffer>>,
+) {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 3.5, 3.5))
+            .looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    let background = LinearRgba::new(0.05, 0.05, 0.08, 1.0);
+
+    let mut rng = Rng::new(67676767); // lol
+    let points: Vec<[Vec2; 4]> = (0..CURVE_COLORS.len())
+        .map(|_| {
+            [
+                Vec2::new(
+                    rng.range(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX),
+                    rng.range(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX),
+                ),
+                Vec2::new(
+                    rng.range(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX),
+                    rng.range(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX),
+                ),
+                Vec2::new(
+                    rng.range(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX),
+                    rng.range(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX),
+                ),
+                Vec2::new(
+                    rng.range(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX),
+                    rng.range(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX),
+                ),
+            ]
+        })
+        .collect();
+    let velocities = vec![[Vec2::ZERO; 4]; points.len()];
+
+    let curves: Vec<BezierCurve> = points
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            BezierCurve::new(p[0], p[1], p[2], p[3])
+                .with_color(CURVE_COLORS[i])
+                .with_width(CURVE_WIDTH)
+        })
+        .collect();
+
+    let material = materials.add(BezierMaterial::from_curves(
+        background,
+        curves,
+        &mut storage_buffers,
+    ));
+
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(2.5)))),
+        MeshMaterial3d(material.clone()),
+    ));
+
+    commands.insert_resource(WanderingCurves {
+        material,
+        background,
+        points,
+        velocities,
+        rng,
+    });
+}
+
+fn wander_control_points(
+    time: Res<Time>,
+    mut wandering: ResMut<WanderingCurves>,
+    mut materials: ResMut<Assets<BezierMaterial>>,
+    mut storage_buffers: ResMut<Assets<ShaderStorageBuffer>>,
+) {
+    let dt = time.delta_secs();
+    let WanderingCurves {
+        points,
+        velocities,
+        rng,
+        ..
+    } = &mut *wandering;
+
+    for (point, velocity) in
+        points.iter_mut().zip(velocities.iter_mut())
+    {
+        for (p, v) in point.iter_mut().zip(velocity.iter_mut()) {
+            // random accel values
+            *v +=
+                Vec2::new(rng.range(-1.0, 1.0), rng.range(-1.0, 1.0))
+                    * ACCEL
+                    * dt;
+            *v = v.clamp_length_max(MAX_SPEED);
+            *p += *v * dt;
+
+            if p.x < POINT_BOUNDS_MIN || p.x > POINT_BOUNDS_MAX {
+                p.x = p.x.clamp(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX);
+                v.x = -v.x;
+            }
+            if p.y < POINT_BOUNDS_MIN || p.y > POINT_BOUNDS_MAX {
+                p.y = p.y.clamp(POINT_BOUNDS_MIN, POINT_BOUNDS_MAX);
+                v.y = -v.y;
+            }
+        }
+    }
+
+    let curves: Vec<BezierCurve> = points
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            BezierCurve::new(p[0], p[1], p[2], p[3])
+                .with_color(CURVE_COLORS[i])
+                .with_width(CURVE_WIDTH)
+            // .with_debug(true)
+        })
+        .collect();
+
+    if let Some(material) = materials.get(&wandering.material) {
+        material.update_curves(
+            wandering.background,
+            &curves,
+            &mut storage_buffers,
+        );
+    }
+
+    // doesnt automatically reload the material, so mark it to force a rebuild
+    // NOTE: might be expensive
+    materials.get_mut(&wandering.material);
+}

--- a/examples/bezier_realtime.rs
+++ b/examples/bezier_realtime.rs
@@ -85,7 +85,7 @@ fn setup(
             .looking_at(Vec3::ZERO, Vec3::Y),
     ));
 
-    let background = LinearRgba::new(0.05, 0.05, 0.08, 1.0);
+    let background = LinearRgba::new(0.05, 0.05, 0.08, 0.0);
 
     let mut rng = Rng::new(67676767); // lol
     let points: Vec<[Vec2; 4]> = (0..CURVE_COLORS.len())

--- a/examples/bezier_single.rs
+++ b/examples/bezier_single.rs
@@ -1,0 +1,59 @@
+//! Example: one plane with two cubic Bezier curves.
+//!
+//! The plane lies in the XZ plane (normal = +Y).
+//! Control points are in UV space: (0,0) = one corner, (1,1) = opposite corner.
+
+use bevy::prelude::*;
+use bevy::render::storage::ShaderStorageBuffer;
+use xad::bezier::{BezierCurve, BezierMaterial, BezierPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, BezierPlugin))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<BezierMaterial>>,
+    mut storage_buffers: ResMut<Assets<ShaderStorageBuffer>>,
+) {
+    // Angled top-down camera.
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 3.5, 3.5))
+            .looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    let material = materials.add(BezierMaterial::from_curves(
+        LinearRgba::new(0.06, 0.06, 0.10, 1.0),
+        vec![
+            // Orange S-curve
+            BezierCurve::new(
+                Vec2::new(0.10, 0.20),
+                Vec2::new(0.40, 0.90),
+                Vec2::new(0.60, 0.10),
+                Vec2::new(0.90, 0.80),
+            )
+            .with_color(LinearRgba::new(1.00, 0.45, 0.10, 1.0))
+            .with_width(0.005),
+            // Cyan arch
+            BezierCurve::new(
+                Vec2::new(0.10, 0.50),
+                Vec2::new(0.35, 0.95),
+                Vec2::new(0.65, 0.95),
+                Vec2::new(0.90, 0.50),
+            )
+            .with_color(LinearRgba::new(0.20, 0.80, 1.00, 1.0))
+            .with_width(0.005),
+        ],
+        &mut storage_buffers,
+    ));
+
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(2.5)))),
+        MeshMaterial3d(material),
+    ));
+}

--- a/src/bezier.rs
+++ b/src/bezier.rs
@@ -1,0 +1,166 @@
+use bevy::prelude::*;
+use bevy::render::render_resource::{AsBindGroup, ShaderType};
+use bevy::render::storage::ShaderStorageBuffer;
+use bevy::shader::ShaderRef;
+
+pub struct BezierPlugin;
+
+impl Plugin for BezierPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(MaterialPlugin::<BezierMaterial>::default());
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, ShaderType)]
+pub struct BezierCurve {
+    // Control points
+    pub p0: Vec2,
+    pub p1: Vec2,
+    pub p2: Vec2,
+    pub p3: Vec2,
+
+    pub color: Vec4,
+
+    // Half-width
+    pub width: f32,
+
+    // 0: quadratic (p0..p2)
+    // 1: cubic (p0..p3)
+    pub kind: u32,
+
+    // 0: Dont show
+    // 1: Show control points
+    pub debug: u32,
+}
+
+impl BezierCurve {
+    pub fn new(p0: Vec2, p1: Vec2, p2: Vec2, p3: Vec2) -> Self {
+        Self {
+            p0,
+            p1,
+            p2,
+            p3,
+            color: Vec4::ONE,
+            width: 0.012,
+            kind: 1,
+            debug: 0,
+        }
+    }
+
+    pub fn new_quadratic(p0: Vec2, p1: Vec2, p2: Vec2) -> Self {
+        Self {
+            p0,
+            p1,
+            p2,
+            p3: Vec2::ZERO, // TODO: consider to maybe set p3 = p2? does the math work?
+            color: Vec4::ONE,
+            width: 0.012,
+            kind: 0,
+            debug: 0,
+        }
+    }
+
+    pub fn with_color(mut self, color: LinearRgba) -> Self {
+        self.color = Vec4::new(
+            color.red,
+            color.green,
+            color.blue,
+            color.alpha,
+        );
+        self
+    }
+
+    pub fn with_width(mut self, width: f32) -> Self {
+        self.width = width;
+        self
+    }
+
+    pub fn with_debug(mut self, debug: bool) -> Self {
+        self.debug = debug as u32;
+        self
+    }
+}
+
+// Matches `MAX_CURVES` in WGSL shader
+pub const MAX_BEZIER_CURVES: usize = 32;
+
+// Fixed-size GPU layout: background + count + curves
+#[derive(ShaderType, Clone, Copy, Default)]
+struct BezierGpuData {
+    background_color: Vec4, // 16 bytes
+    curve_count: u32,       // 4 bytes
+    // cache localisation
+    // 12 bytes explicit padding so `curves` lands at a 16-byte boundary (offset 32).
+    _pad0: [f32; 3], // 12 bytes
+    curves: [BezierCurve; 32],
+}
+
+// Material that draws cubic Bezier curves on a mesh surface
+#[derive(Asset, TypePath, AsBindGroup, Clone)]
+pub struct BezierMaterial {
+    #[storage(0, read_only)]
+    pub buffer: Handle<ShaderStorageBuffer>,
+}
+
+impl BezierMaterial {
+    // Constructs material based on list of curves and a background colour
+    pub fn from_curves(
+        background: LinearRgba,
+        curves: Vec<BezierCurve>,
+        storage_buffers: &mut Assets<ShaderStorageBuffer>,
+    ) -> Self {
+        let mut data = BezierGpuData {
+            background_color: Vec4::new(
+                background.red,
+                background.green,
+                background.blue,
+                background.alpha,
+            ),
+            curve_count: curves.len().min(MAX_BEZIER_CURVES) as u32,
+            ..Default::default()
+        };
+        for (i, curve) in
+            curves.into_iter().enumerate().take(MAX_BEZIER_CURVES)
+        {
+            data.curves[i] = curve;
+        }
+        Self {
+            buffer: storage_buffers
+                .add(ShaderStorageBuffer::from(data)),
+        }
+    }
+
+    // Overwrites the material's GPU buffer in place, with new background
+    // and curve
+    pub fn update_curves(
+        &self,
+        background: LinearRgba,
+        curves: &[BezierCurve],
+        storage_buffers: &mut Assets<ShaderStorageBuffer>,
+    ) {
+        let mut data = BezierGpuData {
+            background_color: Vec4::new(
+                background.red,
+                background.green,
+                background.blue,
+                background.alpha,
+            ),
+            curve_count: curves.len().min(MAX_BEZIER_CURVES) as u32,
+            ..Default::default()
+        };
+        for (i, curve) in
+            curves.iter().enumerate().take(MAX_BEZIER_CURVES)
+        {
+            data.curves[i] = *curve;
+        }
+        if let Some(buffer) = storage_buffers.get_mut(&self.buffer) {
+            buffer.set_data(data);
+        }
+    }
+}
+
+impl Material for BezierMaterial {
+    fn fragment_shader() -> ShaderRef {
+        "shaders/bezier.wgsl".into()
+    }
+}

--- a/src/bezier.rs
+++ b/src/bezier.rs
@@ -163,4 +163,8 @@ impl Material for BezierMaterial {
     fn fragment_shader() -> ShaderRef {
         "shaders/bezier.wgsl".into()
     }
+
+    fn alpha_mode(&self) -> AlphaMode {
+        AlphaMode::Blend
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ use bevy::prelude::*;
 pub mod camera;
 pub mod sdf;
 
+pub mod bezier;
+
 use camera::CameraPlugin;
 use sdf::SdfPlugin;
 


### PR DESCRIPTION
This feature enables the drawing of Bezier curves, of which all other 2D shapes are a derivative of. Both quadratic and cubic curves are supported, with cubic being a combination of two quadratic curves.

This PR also introduces a pseudo-definition of a plane and a sketch.

How a Bezier curve is drawn:
1. Create a material (`BezierMaterial`)
2. Assign curves to the material (`BezierCurve`)
3. Instantiate the material into the world, typically drawn on a `Mesh3d` acting as the plane.
4. If updates are required, do it through `BezierMaterial`'s `update_curves`.

**Future enhancements:**
- Creation of sketches measured in global units, not in material UV coordinates
- Calculating material bounding box based on curves

**Examples and Demonstrations:**
1. `bezier_single` - Singular `BezierMaterial`
<img width="1276" height="721" alt="image" src="https://github.com/user-attachments/assets/a979d661-4256-4c07-9452-e3a31f55ec5e" />

2. `bezier_multi` - Multiple `BezierMaterial` on different planes
<img width="1278" height="721" alt="image" src="https://github.com/user-attachments/assets/d6e4ecff-1661-4eda-bb33-dc4f8c6dcbea" />

3. `bezier_realtime` - Updating the `BezierMaterial` in realtime
https://github.com/user-attachments/assets/d35138c8-f38e-4846-8e3d-b110c7182636


