### PR TITLE
Sketch features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6237,6 +6237,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_egui",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 bevy = { version = "0.18.0", default-features = false, features = ["3d", "file_watcher"] }
 bevy_egui = "0.39.0"
+rand = "0.9.2"
 
 [[example]]
 name = "bezier_single"
@@ -18,3 +19,7 @@ path = "examples/bezier_multi.rs"
 [[example]]
 name = "bezier_realtime"
 path = "examples/bezier_realtime.rs"
+
+[[example]]
+name = "bezier_sketch"
+path = "examples/bezier_sketch.rs"

--- a/assets/shaders/bezier.wgsl
+++ b/assets/shaders/bezier.wgsl
@@ -14,6 +14,9 @@ struct BezierCurve {
     kind:  u32,
     // non-zero = draw control points
     debug: u32,
+    // non-zero = draw a dot at each endpoint
+    draw_endpoints: u32,
+    endpoint_radius: f32,
 }
 
 struct BezierBuffer {
@@ -178,6 +181,16 @@ fn draw_debug_overlay(color: vec3f, uv: vec2f, curve: BezierCurve) -> vec3f {
 }
 // 
 
+fn draw_endpoint(canvas: vec4f, uv: vec2f, p: vec2f, radius: f32, dot_color: vec4f) -> vec4f {
+    let d        = distance(uv, p);
+    let aa       = fwidth(d);
+    let mask     = 1.0 - smoothstep(radius - aa, radius + aa, d);
+    let coverage = mask * dot_color.a;
+    let color    = mix(canvas.rgb, dot_color.rgb, coverage);
+    let alpha    = mix(canvas.a, 1.0, coverage);
+    return vec4f(color, alpha);
+}
+
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4f {
     let uv   = in.uv;
@@ -200,6 +213,15 @@ fn fragment(in: VertexOutput) -> @location(0) vec4f {
 
         if (curve.debug != 0u) {
             color = draw_debug_overlay(color, uv, curve);
+        }
+
+        if (curve.draw_endpoints != 0u) {
+            let last_point = select(curve.p2, curve.p3, curve.kind != 0u);
+            var canvas = vec4f(color, alpha);
+            canvas = draw_endpoint(canvas, uv, curve.p0, curve.endpoint_radius, curve.color);
+            canvas = draw_endpoint(canvas, uv, last_point, curve.endpoint_radius, curve.color);
+            color = canvas.rgb;
+            alpha = canvas.a;
         }
     }
 

--- a/examples/bezier_sketch.rs
+++ b/examples/bezier_sketch.rs
@@ -1,0 +1,127 @@
+//! Example: a simple 2D sketch that draws some basic shapes (square, hexagon, a heart <3, and a circle)
+
+use bevy::prelude::*;
+use bevy::render::storage::ShaderStorageBuffer;
+use xad::bezier::{BezierCurve, BezierMaterial, BezierPlugin};
+use xad::sketch::color::gen_color;
+use xad::sketch::features::circle::circle;
+use xad::sketch::features::line::line as feature_line;
+use xad::sketch::features::polygon::polygon as feature_polygon;
+use xad::sketch::features::square::square as feature_square;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, BezierPlugin))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+const HALF_EXTENT: f32 = 1.0;
+const LINE_WIDTH: f32 = 0.005;
+const ENDPOINT_RADIUS: f32 = 0.015;
+
+// Wraps the shared `line` helper with this example's endpoint-dot styling.
+fn line(a: Vec2, b: Vec2, color: LinearRgba) -> BezierCurve {
+    feature_line(a, b, color, LINE_WIDTH)
+        .with_draw_endpoints(true)
+        .with_endpoint_radius(ENDPOINT_RADIUS)
+}
+
+fn square(color: LinearRgba) -> Vec<BezierCurve> {
+    feature_square(Vec2::splat(0.5), 0.6, color, LINE_WIDTH)
+        .into_iter()
+        .map(|c| {
+            c.with_draw_endpoints(true)
+                .with_endpoint_radius(ENDPOINT_RADIUS)
+        })
+        .collect()
+}
+
+fn hexagon(color: LinearRgba) -> Vec<BezierCurve> {
+    let center = Vec2::new(0.5, 0.5);
+    let radius = 0.35;
+    let vertices: Vec<Vec2> = (0..6)
+        .map(|i| {
+            // i/6 * 2PI + (PI/2)
+            // PI/2 offset is so that its a flat top hexagon
+            let angle = std::f32::consts::TAU * (i as f32) / 6.0
+                + std::f32::consts::FRAC_PI_2;
+            center + radius * Vec2::new(angle.cos(), angle.sin())
+        })
+        .collect();
+    feature_polygon(&vertices, color, LINE_WIDTH)
+}
+
+// Two mirrored cubic curves sharing a bottom tip and a top notch.
+fn heart(color: LinearRgba) -> Vec<BezierCurve> {
+    let tip = Vec2::new(0.5, 0.85);
+    let notch = Vec2::new(0.5, 0.4);
+    vec![
+        BezierCurve::new(
+            tip,
+            Vec2::new(0.05, 0.7),
+            Vec2::new(0.05, 0.25),
+            notch,
+        )
+        .with_color(color)
+        .with_width(LINE_WIDTH)
+        .with_draw_endpoints(true)
+        .with_endpoint_radius(0.015),
+        BezierCurve::new(
+            tip,
+            Vec2::new(0.95, 0.7),
+            Vec2::new(0.95, 0.25),
+            notch,
+        )
+        .with_color(color)
+        .with_width(LINE_WIDTH)
+        .with_draw_endpoints(true)
+        .with_endpoint_radius(0.015),
+    ]
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<BezierMaterial>>,
+    mut storage_buffers: ResMut<Assets<ShaderStorageBuffer>>,
+) {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 9.0, 9.0))
+            .looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    let background = LinearRgba::new(0.06, 0.06, 0.09, 1.0);
+    let mesh =
+        meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(HALF_EXTENT)));
+
+    let shapes = [
+        (Vec3::new(-3.75, 0.0, 0.0), square(gen_color())),
+        (Vec3::new(-1.25, 0.0, 0.0), hexagon(gen_color())),
+        (Vec3::new(1.25, 0.0, 0.0), heart(gen_color())),
+        (
+            Vec3::new(3.75, 0.0, 0.0),
+            circle(Vec2::splat(0.5), 0.32, gen_color(), LINE_WIDTH)
+                .into_iter()
+                .map(|c| {
+                    c.with_draw_endpoints(true)
+                        .with_endpoint_radius(ENDPOINT_RADIUS)
+                })
+                .collect(),
+        ),
+    ];
+
+    for (translation, curves) in shapes {
+        let material = materials.add(BezierMaterial::from_curves(
+            background,
+            curves,
+            &mut storage_buffers,
+        ));
+        commands.spawn((
+            Mesh3d(mesh.clone()),
+            MeshMaterial3d(material),
+            Transform::from_translation(translation),
+        ));
+    }
+}

--- a/src/bezier.rs
+++ b/src/bezier.rs
@@ -31,6 +31,13 @@ pub struct BezierCurve {
     // 0: Dont show
     // 1: Show control points
     pub debug: u32,
+
+    // 0: Dont show
+    // 1: Show a dot at each endpoint (p0 and the last control point)
+    pub draw_endpoints: u32,
+
+    // Radius of the endpoint dots
+    pub endpoint_radius: f32,
 }
 
 impl BezierCurve {
@@ -44,6 +51,8 @@ impl BezierCurve {
             width: 0.012,
             kind: 1,
             debug: 0,
+            draw_endpoints: 0,
+            endpoint_radius: 0.02,
         }
     }
 
@@ -57,6 +66,8 @@ impl BezierCurve {
             width: 0.012,
             kind: 0,
             debug: 0,
+            draw_endpoints: 0,
+            endpoint_radius: 0.02,
         }
     }
 
@@ -77,6 +88,22 @@ impl BezierCurve {
 
     pub fn with_debug(mut self, debug: bool) -> Self {
         self.debug = debug as u32;
+        self
+    }
+
+    pub fn with_draw_endpoints(
+        mut self,
+        draw_endpoints: bool,
+    ) -> Self {
+        self.draw_endpoints = draw_endpoints as u32;
+        self
+    }
+
+    pub fn with_endpoint_radius(
+        mut self,
+        endpoint_radius: f32,
+    ) -> Self {
+        self.endpoint_radius = endpoint_radius;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod camera;
 pub mod sdf;
 
 pub mod bezier;
+pub mod sketch;
 
 use camera::CameraPlugin;
 use sdf::SdfPlugin;

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -1,0 +1,3 @@
+pub mod color;
+pub mod features;
+

--- a/src/sketch/color.rs
+++ b/src/sketch/color.rs
@@ -1,0 +1,18 @@
+use bevy::prelude::LinearRgba;
+use rand::seq::IndexedRandom;
+
+// TODO: consider throwing this into some sort of config instead of hardcoding it
+const PALETTE: [LinearRgba; 7] = [
+    // random colours
+    LinearRgba::new(1.00, 0.55, 0.10, 1.0), // orange
+    LinearRgba::new(0.20, 0.80, 1.00, 1.0), // cyan
+    LinearRgba::new(1.00, 0.25, 0.45, 1.0), // pink
+    LinearRgba::new(0.55, 1.00, 0.35, 1.0), // green
+    LinearRgba::new(1.00, 0.85, 0.10, 1.0), // yellow
+    LinearRgba::new(0.90, 0.40, 1.00, 1.0), // purple
+    LinearRgba::new(1.00, 0.30, 0.30, 1.0), // red
+];
+
+pub fn gen_color() -> LinearRgba {
+    *PALETTE.choose(&mut rand::rng()).unwrap()
+}

--- a/src/sketch/features.rs
+++ b/src/sketch/features.rs
@@ -1,0 +1,6 @@
+pub mod arc;
+pub mod circle;
+pub mod line;
+pub mod polygon;
+pub mod rectangle;
+pub mod square;

--- a/src/sketch/features/arc.rs
+++ b/src/sketch/features/arc.rs
@@ -1,0 +1,48 @@
+use std::f32::consts::PI;
+
+use bevy::prelude::*;
+
+use crate::bezier::BezierCurve;
+
+const MAX_SEGMENT_SWEEP: f32 = PI / 2.0;
+
+pub fn arc(
+    center: Vec2,
+    radius: f32,
+    start_angle: f32,
+    end_angle: f32,
+    color: LinearRgba,
+    stroke_width: f32,
+) -> Vec<BezierCurve> {
+    let sweep = end_angle - start_angle;
+    let segment_count =
+        (sweep.abs() / MAX_SEGMENT_SWEEP).ceil().max(1.0) as usize;
+    let segment_sweep = sweep / segment_count as f32;
+
+    (0..segment_count)
+        .map(|i| {
+            let a0 = start_angle + segment_sweep * i as f32;
+            let a1 = a0 + segment_sweep;
+            arc_segment(center, radius, a0, a1, color, stroke_width)
+        })
+        .collect()
+}
+
+fn arc_segment(
+    center: Vec2,
+    radius: f32,
+    a0: f32,
+    a1: f32,
+    color: LinearRgba,
+    stroke_width: f32,
+) -> BezierCurve {
+    let p0 = center + radius * Vec2::new(a0.cos(), a0.sin());
+    let p3 = center + radius * Vec2::new(a1.cos(), a1.sin());
+    let handle = (4.0 / 3.0) * ((a1 - a0) / 4.0).tan() * radius;
+    let p1 = p0 + handle * Vec2::new(-a0.sin(), a0.cos());
+    let p2 = p3 - handle * Vec2::new(-a1.sin(), a1.cos());
+
+    BezierCurve::new(p0, p1, p2, p3)
+        .with_color(color)
+        .with_width(stroke_width)
+}

--- a/src/sketch/features/circle.rs
+++ b/src/sketch/features/circle.rs
@@ -1,0 +1,15 @@
+use std::f32::consts::TAU;
+
+use bevy::prelude::*;
+
+use crate::bezier::BezierCurve;
+use crate::sketch::features::arc::arc;
+
+pub fn circle(
+    center: Vec2,
+    radius: f32,
+    color: LinearRgba,
+    stroke_width: f32,
+) -> Vec<BezierCurve> {
+    arc(center, radius, 0.0, TAU, color, stroke_width)
+}

--- a/src/sketch/features/line.rs
+++ b/src/sketch/features/line.rs
@@ -1,0 +1,14 @@
+use bevy::prelude::*;
+
+use crate::bezier::BezierCurve;
+
+pub fn line(
+    a: Vec2,
+    b: Vec2,
+    color: LinearRgba,
+    stroke_width: f32,
+) -> BezierCurve {
+    BezierCurve::new(a, a.lerp(b, 1.0 / 3.0), a.lerp(b, 2.0 / 3.0), b)
+        .with_color(color)
+        .with_width(stroke_width)
+}

--- a/src/sketch/features/polygon.rs
+++ b/src/sketch/features/polygon.rs
@@ -1,0 +1,21 @@
+use bevy::color::LinearRgba;
+use bevy::math::Vec2;
+
+use crate::bezier::BezierCurve;
+
+pub fn polygon(
+    vertices: &[Vec2],
+    color: LinearRgba,
+    stroke_width: f32,
+) -> Vec<BezierCurve> {
+    (0..vertices.len())
+        .map(|i| {
+            crate::sketch::features::line::line(
+                vertices[i],
+                vertices[(i + 1) % vertices.len()],
+                color,
+                stroke_width,
+            )
+        })
+        .collect()
+}

--- a/src/sketch/features/rectangle.rs
+++ b/src/sketch/features/rectangle.rs
@@ -1,0 +1,30 @@
+use bevy::prelude::*;
+
+use crate::bezier::BezierCurve;
+use crate::sketch::features::line::line;
+
+// axis aligned
+pub fn rectangle(
+    center: Vec2,
+    size: Vec2,
+    color: LinearRgba,
+    stroke_width: f32,
+) -> Vec<BezierCurve> {
+    let half = size * 0.5;
+    let corners = [
+        center + Vec2::new(-half.x, -half.y),
+        center + Vec2::new(half.x, -half.y),
+        center + Vec2::new(half.x, half.y),
+        center + Vec2::new(-half.x, half.y),
+    ];
+    (0..corners.len())
+        .map(|i| {
+            line(
+                corners[i],
+                corners[(i + 1) % corners.len()],
+                color,
+                stroke_width,
+            )
+        })
+        .collect()
+}

--- a/src/sketch/features/square.rs
+++ b/src/sketch/features/square.rs
@@ -1,0 +1,14 @@
+use bevy::prelude::*;
+
+use crate::bezier::BezierCurve;
+use crate::sketch::features::rectangle::rectangle;
+
+// axis aligned
+pub fn square(
+    center: Vec2,
+    side: f32,
+    color: LinearRgba,
+    stroke_width: f32,
+) -> Vec<BezierCurve> {
+    rectangle(center, Vec2::splat(side), color, stroke_width)
+}


### PR DESCRIPTION
Creation of sketch features using Bezier curves. In short, creating pre-defined custom shapes using a combination of bezier curves.

**Examples & demonstration:**
`bezier_sketch` showing off a few sketch features available (`arc`, `circle`, `line`, `polygon`, `rectangle`, `square`)

<img width="986" height="405" alt="image" src="https://github.com/user-attachments/assets/9304a05f-b119-4cbf-96e9-a33265efc394" />
